### PR TITLE
fix(api): serve static files on frontend routes

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -60,11 +60,11 @@ func newRouter(logger *zap.Logger, config config.Config) *gin.Engine {
 	if err != nil {
 		logger.Fatal("Failed to find current root path", zap.Error(err))
 	}
-	staticPath := path.Join(currentRootPath, staticFilesPath)
-	router.Use(static.Serve("/", static.LocalFile(staticPath, false)))
+	fullStaticFilesPath := path.Join(currentRootPath, staticFilesPath)
+	router.Use(static.Serve("/", static.LocalFile(fullStaticFilesPath, false)))
 	router.NoRoute(func(c *gin.Context) {
 		if !strings.HasPrefix(c.Request.RequestURI, apiPrefix) {
-			c.File(staticPath)
+			c.File(fullStaticFilesPath)
 		}
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Serves the frontend application static files on non-api routes (any route that is not prefixed with /v1).
This ensures that the frontend SPA routing would work, as the control over the routes would pass to react router.

**Which issue(s) this PR fixes**:
Fixes #138 