### PR TITLE
fix: serves static files correctly

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,7 +16,10 @@ import (
 	"oss-tracing/pkg/config"
 )
 
-const staticFilesPath = "/web/build"
+const (
+	apiPrefix       = "/v1"
+	staticFilesPath = "/web/build"
+)
 
 // API holds the config used for running the API as well as
 // the endpoint handlers and resources used by them (e.g. logger).
@@ -71,11 +74,11 @@ func (api *API) registerRoutes() {
 	absoluteStaticFilesPath := path.Join(currentRootPath, staticFilesPath)
 	api.router.Use(static.Serve("/", static.LocalFile(absoluteStaticFilesPath, false)))
 	api.router.NoRoute(func(c *gin.Context) {
-		if !strings.HasPrefix(c.Request.RequestURI, "/v1") {
+		if !strings.HasPrefix(c.Request.RequestURI, apiPrefix) {
 			c.File(path.Join(absoluteStaticFilesPath, "index.html"))
 		}
 	})
-	v1 := api.router.Group("/v1")
+	v1 := api.router.Group(apiPrefix)
 	v1.GET("/ping", api.getPing)
 }
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestLoggerMiddleware(t *testing.T) {
-	pingRoute := "/v1/ping"
+	pingRoute := path.Join(apiPrefix, "/ping")
 	fakeLogger, observedLogs := getLoggerObserver()
 	cfg := config.Config{Debug: false}
 	req, _ := http.NewRequest(http.MethodGet, pingRoute, nil)
@@ -63,7 +63,7 @@ func TestRecoveryLoggerMiddleware(t *testing.T) {
 func TestPingRoute(t *testing.T) {
 	fakeLogger, _ := getLoggerObserver()
 	cfg := config.Config{Debug: false}
-	req, _ := http.NewRequest(http.MethodGet, "/v1/ping", nil)
+	req, _ := http.NewRequest(http.MethodGet, path.Join(apiPrefix, "/ping"), nil)
 	resRecorder := httptest.NewRecorder()
 
 	api := NewAPI(fakeLogger, cfg)

--- a/web/src/components/core/App/index.tsx
+++ b/web/src/components/core/App/index.tsx
@@ -5,6 +5,7 @@ import { Layout } from "../Layout";
 export function App() {
   return (
     <Routes>
+      <Route path="*" element={<h1>404 Page not found</h1>} />
       <Route path="/" element={<Layout />}>
         <Route index element={<h1>Homepage</h1>} />
         <Route path="traces" element={<h1>Traces</h1>} />


### PR DESCRIPTION
**What this PR does**:
Serves static files correctly for our frontend application.
All routes that does not have prefix of `/v1` will be redirected to react router.
Credit for the [solution](https://github.com/gin-gonic/contrib/issues/90#issuecomment-990237367)

**Which issue(s) this PR fixes**:
Fixes #138 

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
