### PR TITLE
fix: added ignore file for eslint

### DIFF
--- a/web/.eslintignore
+++ b/web/.eslintignore
@@ -1,0 +1,1 @@
+craco.config.js


### PR DESCRIPTION
**What this PR does**:
Added` .eslintignore` file for ignoring files by `eslint`.
**Which issue(s) this PR fixes**:
`typescript-eslint` plugin checks all `ts` and `js` files 
https://github.com/typescript-eslint/typescript-eslint/issues/1724
we want to add the ability for ignoring some files `js` files
