### PR TITLE
fix(ci): failed auto assign on mergify PRs

### DIFF
--- a/.github/workflows/assign-pr-to-opener.yml
+++ b/.github/workflows/assign-pr-to-opener.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   assign-pr-to-opener:
+    if: ${{ !startsWith(github.head_ref, 'mergify/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Migrate user id


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
- Each draft PR opened by Mergify is failing the ["Change PR assignee on open" action](https://github.com/epsagon/lupa/actions/workflows/assign-pr-to-opener.yml) due to it being opened by a bot account.
- The draft PRs are temporary and only used for running the CI pipeline on PR batches, they are never merged.
- This PR fixes the failure by skipping the auto-assign job for PRs opened by Mergify.
- It might be possible to fix the issue by actually assigning the bot account to the draft PR, but I don't see much benefit in investing time in it due to it being a temporary, short lived PRs that shouldn't be connected to any notifications/tickets systems. Keep in mind that the result of the draft PR is always reported back to the original PR, where the actual opener is assigned. I'm currently more concerned with having a consistent failures in one of our actions due to a bug and not an actual issue.