### PR TITLE
fix: adjust golangci-lint action timeout

### DIFF
--- a/.github/workflows/validate-backend.yml
+++ b/.github/workflows/validate-backend.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           version: v1.49
           only-new-issues: true
+          args: --timeout=5m
 
   golangci-test:
     name: Golang Unit Tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adjusts golangci-lint action timeout.
We had multiple action timeouts recently due to this issue.
It is the recommended approach according to past issues in the action repo.
