### PR TITLE
feat: align internal span model with OTel

### DIFF
--- a/pkg/model/internalspan/v1/internal_span.go
+++ b/pkg/model/internalspan/v1/internal_span.go
@@ -10,8 +10,8 @@ type SpanEvent struct {
 }
 
 type SpanLink struct {
-	TraceId                []byte
-	SpanId                 []byte
+	TraceId                [16]byte
+	SpanId                 [8]byte
 	TraceState             string
 	Attributes             Attributes
 	DroppedAttributesCount uint32
@@ -24,27 +24,27 @@ type SpanStatus struct {
 
 type Resource struct {
 	Attributes             Attributes
-	DroppedAttributesCount int32
+	DroppedAttributesCount uint32
 }
 
 type InstrumentationScope struct {
 	Name                   string
 	Version                string
 	Attributes             Attributes
-	DroppedAttributesCount int32
+	DroppedAttributesCount uint32
 }
 
 type Span struct {
-	TraceId                []byte
-	SpanId                 []byte
+	TraceId                [16]byte
+	SpanId                 [8]byte
 	TraceState             string
-	ParentSpanId           []byte
+	ParentSpanId           [8]byte
 	Name                   string
 	Kind                   int32
 	StartTimeUnixNano      uint64
 	EndTimeUnixNano        uint64
 	Attributes             Attributes
-	DroppedAttributesCount int32
+	DroppedAttributesCount uint32
 	Events                 []*SpanEvent
 	DroppedEventsCount     uint32
 	Links                  []*SpanLink
@@ -57,9 +57,9 @@ type ExternalFields struct {
 }
 
 type InternalSpan struct {
-	Resource       *Resource
-	Scope          *InstrumentationScope
-	Span           *Span
-	ExternalFields *ExternalFields
-	TimestampNano  uint64
+	Resource              *Resource
+	Scope                 *InstrumentationScope
+	Span                  *Span
+	ExternalFields        *ExternalFields
+	IngestionTimeUnixNano uint64
 }

--- a/pkg/model/internalspan/v1/util/internal_span_mock.go
+++ b/pkg/model/internalspan/v1/util/internal_span_mock.go
@@ -16,8 +16,8 @@ func GenInternalSpan(s_attr map[string]any, r_attr map[string]any, i_attr map[st
 			Attributes: i_attr,
 		},
 		Span: &v1.Span{
-			TraceId:         []byte("UUID_RANDOM"),
-			SpanId:          []byte("UUID_RANDOM"),
+			TraceId:         [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1},
+			SpanId:          [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
 			TraceState:      "state",
 			Name:            "span_name",
 			Kind:            1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Currently, the internal span model we are using is not aligned with the types used in the official OTel libs ([collector](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/data/protogen/trace/v1/trace.pb.go)/[go sdk](https://github.com/open-telemetry/opentelemetry-go/blob/main/trace/trace.go)).
We are using the same exact properties defined in the official OTel trace definition, therefore there is no reason to change the properties types and cause unnecessary type assertions throughout the code.


**Which issue(s) this PR fixes**:
Part of #104 
