### PR TITLE
feat: run collector in AIO docker image

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -2,14 +2,10 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19-alpine3.16 as backend-
 
 WORKDIR /app
 
-
-# COPY go.mod, go.sum and download the dependencies
-COPY go.* ./
-RUN go mod download
-
 # COPY All things inside the project and build
 COPY . .
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /app/build/bin ./cmd/all-in-one
+
 
 FROM node:18-alpine3.16 AS ui-builder
 ENV NODE_ENV production

--- a/cmd/all-in-one/README.md
+++ b/cmd/all-in-one/README.md
@@ -36,11 +36,25 @@ Alternatively, using docker CLI:
 
 ```sh
 docker build -f cmd/all-in-one/Dockerfile -t oss-tracing:latest .
-docker run -p 8080:8080 -p 4317:4317 -p 4318:4318 oss-tracing:latest
+docker run \
+    -v $(pwd)/lupa-otelcol/config/default-config.yaml:/etc/config.yaml \
+    -p 8080:8080 \
+    -p 4317:4317 \
+    -p 4318:4318 \
+    oss-tracing:latest \
+    --config /etc/config.yaml
 ```
 
 In case you want to run docker file with environment variables:
 
 ```sh
-docker run -p 9090:9090 -e API_PORT=9090 -e DEBUG=false oss-tracing:latest
+docker run \
+    -v $(pwd)/lupa-otelcol/config/default-config.yaml:/etc/config.yaml \
+    -p 9090:9090 \
+    -p 4317:4317 \
+    -p 4318:4318 \
+    -e API_PORT=9090 \
+    -e DEBUG=false \
+    oss-tracing:latest \
+    --config /etc/config.yaml
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1. Bundles the collector distribution along with the API as a single AIO image.
2. Because of the "replace" directives change #410 , we avoid any issues with fetching remote modules of a private repo.
3. Because of the same reason, we can't cache the packages and have to first copy everything. There might be a better way to do this so we might invest more time into it in the future.

**Which issue(s) this PR fixes**:
Fixes #390 
