### PR TITLE
feat(trace-view): increase trace query stale time

### DIFF
--- a/web/src/features/trace/api/traceQuery.ts
+++ b/web/src/features/trace/api/traceQuery.ts
@@ -17,5 +17,6 @@ export const useTraceQuery = (traceId: string) => {
     queryKey: ["trace", traceId],
     queryFn: () => fetchTrace(traceId),
     select: (traceResponse) => traceResponse.spans,
+    staleTime: 5 * 60 * 1000, // 5 minutes
   });
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
1. Increases the time the trace query is considered up to date.
2. After 5 minutes, an automatic query will be made to the API.
3. By default the stale time is 0, which means that on every render an API call is made.
4. 5 minutes should be balanced enough - not too many requests to the API (each DB search can cost money), but enough time to make sure that changes in the trace (e.g., late spans ingestion) will be reflected in the UI.