### PR TITLE
fix: increased golreleaser timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,6 @@ builds:
     goos:
       - linux
       - windows
-      - darwin
     goarch:
       - amd64
       - arm
@@ -133,7 +132,6 @@ docker_manifests:
 
 archives:
   - replacements:
-      darwin: Darwin
       linux: Linux
       windows: Windows
       386: i386


### PR DESCRIPTION
**What this PR does**:
Increase goreleaser timeout & removed Darwin build.
**Which issue(s) this PR fixes**:
Fixes #513 
