### PR TITLE
fix: increased yarn install timeout

### DIFF
--- a/cmd/all-in-one/Dockerfile
+++ b/cmd/all-in-one/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 # Cache and Install dependencies
 COPY web/package.json .
 COPY web/yarn.lock .
-RUN yarn install
+RUN yarn install --network-timeout 1000000
 
 # Copy app files
 COPY web/ .


### PR DESCRIPTION

**What this PR does**:
Increased yarn install timeout. That change is needed for building the Dockerfile using our release workflow.
See more [here](https://github.com/yarnpkg/yarn/issues/4890)
**Which issue(s) this PR fixes**:
Fixes #513 

