### PR TITLE
fix(trace-view): fix span details overflow

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetailsList/styles.ts
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetailsList/styles.ts
@@ -1,5 +1,6 @@
 export const styles = {
   container: {
     width: "40%",
+    overflow: "auto",
   },
 };

--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -60,16 +60,16 @@ const ProductionTraceView = () => {
         sx={{ height: "100%" }}
       >
         <Stack
-          direction="row"
-          divider={<Divider orientation="vertical" flexItem />}
+          flex={3}
           spacing={2}
-          justifyContent="space-between"
-          flex={1}
+          direction="row"
+          sx={styles.graphSpanDetailsContainer}
+          divider={<Divider orientation="vertical" flexItem />}
         >
           <TraceGraph setSelectedNode={setSelectedNode} spans={trace} />
           <SpanDetailsList spans={selectedNode?.spans} />
         </Stack>
-        <Stack divider={<Divider orientation="vertical" flexItem />} flex={1}>
+        <Stack flex={1} divider={<Divider orientation="vertical" flexItem />}>
           <TraceTimeline trace={trace} />
         </Stack>
       </Stack>

--- a/web/src/features/trace/routes/TraceView/styles.ts
+++ b/web/src/features/trace/routes/TraceView/styles.ts
@@ -5,4 +5,7 @@ export const styles = {
     justifyContent: "center",
     alignItems: "center",
   },
+  graphSpanDetailsContainer: {
+    overflow: "auto",
+  },
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes the span details (tags) component overflow issue that pushes down the trace timeline.
Now a scrollbar will appear when the span details overflows (as per the design).

![Screenshot 2022-11-26 at 19 53 04](https://user-images.githubusercontent.com/37577482/204102438-d74d03cc-860a-40f5-8d5d-4ce66bf9b33d.png)