### PR TITLE
fix: scrollbar dark mode (driven  from theme palette mode)

### DIFF
--- a/web/src/styles/theme.tsx
+++ b/web/src/styles/theme.tsx
@@ -167,6 +167,11 @@ theme = createTheme(theme, {
     },
   },
   components: {
+    MuiCssBaseline: {
+      defaultProps: {
+        enableColorScheme: "true",
+      },
+    },
     MuiAutocomplete: {
       styleOverrides: {
         paper: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
photo attached is when the scrollbar is hovered: 
![image](https://user-images.githubusercontent.com/40536014/204252148-938c5064-ef23-450a-8c7d-131ae6968eaa.png)

**Which issue(s) this PR fixes**:
Fixes #576 

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
