### PR TITLE
fix: Error status disappear from nodes in the trace graph.

### DIFF
--- a/web/src/features/trace/components/TraceGraph/Graph/types.ts
+++ b/web/src/features/trace/components/TraceGraph/Graph/types.ts
@@ -44,7 +44,7 @@ export enum NodeColor {
   NORMAL = "#96979E",
   HOVER = "#FFFFFF",
   SELECTED = "#009EB4",
-  ERR_NORMAL = "#EF5854",
+  ERROR = "#EF5854",
   ERR_SELECTED = "#EF5854",
   ERR_HOVER = "#B52D29",
 }

--- a/web/src/features/trace/components/TraceGraph/Graph/utils/layout.ts
+++ b/web/src/features/trace/components/TraceGraph/Graph/utils/layout.ts
@@ -2,7 +2,7 @@ import Elk, { ElkNode } from "elkjs";
 import { ElkExtendedEdge } from "elkjs/lib/elk-api";
 import { Edge, MarkerType, Node, Position } from "reactflow";
 
-import { InternalSpan } from "@/types/span";
+import { InternalSpan, StatusCode } from "@/types/span";
 
 import {
   EdgeColor,
@@ -85,7 +85,7 @@ const createGraphNode = (
     serviceName: nodeData.name,
     systemType: nodeData.type,
     image: nodeData.image,
-    hasError: internalSpan.span.status.code === 2,
+    hasError: internalSpan.span.status.code === StatusCode.Error,
     duration: internalSpan.externalFields.durationNano,
     spans: [{ ...internalSpan }],
   };
@@ -108,7 +108,7 @@ const updateGraphNode = (
   internalSpan: Readonly<InternalSpan>
 ): void => {
   g.spans.push({ ...internalSpan });
-  g.hasError = g.hasError || internalSpan.span.status.code === 2;
+  g.hasError = g.hasError || internalSpan.span.status.code === StatusCode.Error;
   g.duration = g.duration + internalSpan.externalFields.durationNano;
 };
 
@@ -153,7 +153,7 @@ const createNode = (g: Readonly<GraphNode>): Node<NodeData> => {
       name: g.serviceName,
       type: g.systemType,
       image: g.image,
-      color: g.hasError ? NodeColor.ERR_NORMAL : NodeColor.NORMAL,
+      color: g.hasError ? NodeColor.ERROR : NodeColor.NORMAL,
       graphNode: { ...g },
     },
     position: POSITION,
@@ -175,7 +175,7 @@ const createEdge = (
     data: {
       time: `${Math.round(duration / 1000000)}ms`,
       count: 1,
-      hasError: hasError,
+      hasError,
     },
     style: {
       stroke: hasError ? EdgeColor.ERROR : EdgeColor.NORMAL,

--- a/web/src/features/trace/components/TraceGraph/Graph/utils/utils.ts
+++ b/web/src/features/trace/components/TraceGraph/Graph/utils/utils.ts
@@ -5,40 +5,43 @@ import { EdgeColor, EdgeData, NodeColor, NodeData } from "../types";
 export const applySelectedNodeStyle = (
   node: Node<NodeData>
 ): Node<NodeData> => {
+  const color = node.data.graphNode.hasError
+    ? NodeColor.ERR_SELECTED
+    : NodeColor.SELECTED;
   return {
     ...node,
     selected: true,
     data: {
       ...node.data,
-      color: node.data.graphNode.hasError
-        ? NodeColor.ERR_SELECTED
-        : NodeColor.SELECTED,
+      color,
     },
   };
 };
 
 export const applyNormalNodeStyle = (node: Node<NodeData>): Node<NodeData> => {
+  const color = node.data.graphNode.hasError
+    ? NodeColor.ERROR
+    : NodeColor.NORMAL;
   return {
     ...node,
     selected: false,
     data: {
       ...node.data,
-      color: node.data.graphNode.hasError
-        ? NodeColor.ERR_NORMAL
-        : NodeColor.NORMAL,
+      color,
     },
   };
 };
 
 export const applyHoveredNodeStyle = (node: Node<NodeData>): Node<NodeData> => {
+  const color = node.data.graphNode.hasError
+    ? NodeColor.ERR_HOVER
+    : NodeColor.HOVER;
   return {
     ...node,
     selected: false,
     data: {
       ...node.data,
-      color: node.data.graphNode.hasError
-        ? NodeColor.ERR_HOVER
-        : NodeColor.HOVER,
+      color,
     },
   };
 };
@@ -46,48 +49,53 @@ export const applyHoveredNodeStyle = (node: Node<NodeData>): Node<NodeData> => {
 export const applySelectedEdgeStyle = (
   edge: Edge<EdgeData>
 ): Edge<EdgeData> => {
+  const color = edge.data?.hasError
+    ? EdgeColor.ERR_SELECTED
+    : EdgeColor.SELECTED;
   if (edge.markerEnd && typeof edge.markerEnd !== "string") {
     edge.markerEnd = {
       ...edge.markerEnd,
-      color: edge.data?.hasError ? EdgeColor.ERR_SELECTED : EdgeColor.SELECTED,
+      color,
     };
   }
   if (edge.style) {
     edge.style = {
       ...edge.style,
-      stroke: edge.data?.hasError ? EdgeColor.ERR_SELECTED : EdgeColor.SELECTED,
+      stroke: color,
     };
   }
   return { ...edge, animated: true, selected: true };
 };
 
 export const applyNormalEdgeStyle = (edge: Edge<EdgeData>): Edge<EdgeData> => {
+  const color = edge.data?.hasError ? EdgeColor.ERROR : EdgeColor.NORMAL;
   if (edge.markerEnd && typeof edge.markerEnd !== "string") {
     edge.markerEnd = {
       ...edge.markerEnd,
-      color: edge.data?.hasError ? EdgeColor.ERROR : EdgeColor.NORMAL,
+      color,
     };
   }
   if (edge.style) {
     edge.style = {
       ...edge.style,
-      stroke: edge.data?.hasError ? EdgeColor.ERROR : EdgeColor.NORMAL,
+      stroke: color,
     };
   }
   return { ...edge, animated: false, selected: false };
 };
 
 export const applyHoverEdgeStyle = (edge: Edge<EdgeData>): Edge<EdgeData> => {
+  const color = edge.data?.hasError ? EdgeColor.ERR_HOVER : EdgeColor.HOVER;
   if (edge.markerEnd && typeof edge.markerEnd !== "string") {
     edge.markerEnd = {
       ...edge.markerEnd,
-      color: edge.data?.hasError ? EdgeColor.ERR_HOVER : EdgeColor.HOVER,
+      color,
     };
   }
   if (edge.style) {
     edge.style = {
       ...edge.style,
-      stroke: edge.data?.hasError ? EdgeColor.ERR_HOVER : EdgeColor.HOVER,
+      stroke: color,
     };
   }
   return { ...edge, animated: true, selected: false };


### PR DESCRIPTION
**What this PR does**:
fixed nodes and edges styling when an error exists.
**Which issue(s) this PR fixes**:
Fixes #589 
