### PR TITLE
feat(spans-table): add spanId to trace link

### DIFF
--- a/web/src/features/search/components/SpanTable/SpanTable.tsx
+++ b/web/src/features/search/components/SpanTable/SpanTable.tsx
@@ -78,7 +78,9 @@ export function SpanTable({ filters = [], timeframe }: SpanTableProps) {
   }, [fetchMoreOnBottomReached, tableWrapper]);
 
   const onClick = (row: Row<TableSpan>) => {
-    window.open(`${window.location.origin}/trace/${row.original.traceId}`);
+    window.open(
+      `${window.location.origin}/trace/${row.original.traceId}?spanId=${row.original.spanId}`
+    );
   };
 
   return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Adds `spanId` as query param to the `/trace` URL when clicking on span in the spans table.
Related to #558

**Which issue(s) this PR fixes**:
Part of #538 
