### PR TITLE
fix(trace-view): fix timeline taking entire page

### DIFF
--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -60,7 +60,7 @@ export const TraceView = () => {
         sx={{ height: "100%" }}
       >
         <Stack
-          flex={3}
+          flex={1}
           spacing={2}
           direction="row"
           sx={styles.graphSpanDetailsContainer}
@@ -77,7 +77,10 @@ export const TraceView = () => {
             setSelectedSpanId={setSelectedSpanId}
           />
         </Stack>
-        <Stack flex={1} divider={<Divider orientation="vertical" flexItem />}>
+        <Stack
+          sx={styles.timelineWrapper}
+          divider={<Divider orientation="vertical" flexItem />}
+        >
           <TraceTimeline trace={trace} selectedSpanId={selectedSpanId} />
         </Stack>
       </Stack>

--- a/web/src/features/trace/routes/TraceView/styles.ts
+++ b/web/src/features/trace/routes/TraceView/styles.ts
@@ -11,4 +11,9 @@ export const styles = {
   graphSpanDetailsContainer: {
     overflow: "auto",
   },
+  timelineWrapper: {
+    flex: "0 0 25%",
+    minHeight: "250px",
+    overflow: "auto",
+  },
 };


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
Fixes an issue that occurs when a large trace is rendered by the timeline, which takes up the entire page and hides the trace graph and trace tags components.

**Which issue(s) this PR fixes**:
Fixes #595 

Small trace (no scrollbar):
<img width="1785" alt="Screenshot 2022-11-30 at 11 45 44" src="https://user-images.githubusercontent.com/37577482/204763239-6e499116-5ad8-44f1-8576-582e5f053d7d.png">

Large trace (scrollbar):
<img width="1791" alt="Screenshot 2022-11-30 at 11 45 07" src="https://user-images.githubusercontent.com/37577482/204763336-ae2c5391-0c81-4cda-8734-2732045f882c.png">
<img width="1784" alt="Screenshot 2022-11-30 at 11 45 22" src="https://user-images.githubusercontent.com/37577482/204763351-85526271-faa1-49dc-9a07-2e9f0fd04731.png">