### PR TITLE
fix(trace-view): fix icon rendering and  adjust node style

### DIFF
--- a/web/src/features/trace/components/TraceGraph/BasicNode/BasicNode.tsx
+++ b/web/src/features/trace/components/TraceGraph/BasicNode/BasicNode.tsx
@@ -24,12 +24,10 @@ const BasicNodeImpl = (props: NodeProps<NodeData>) => {
             borderColor: color,
           }}
         >
-          <ResourceIcon name={image} />
+          <ResourceIcon name={image} style={styles.nodeIcon} />
         </Box>
-        <Box sx={styles.nodeTextContainer}>
-          <Box sx={styles.nodeName}>{name}</Box>
-          <Box sx={styles.nodeService}>{type}</Box>
-        </Box>
+        <Box sx={styles.nodeName}>{name}</Box>
+        <Box sx={styles.nodeService}>{type}</Box>
       </Box>
       <Handle
         type="source"

--- a/web/src/features/trace/components/TraceGraph/BasicNode/styles.ts
+++ b/web/src/features/trace/components/TraceGraph/BasicNode/styles.ts
@@ -1,38 +1,35 @@
 export const styles = {
   nodeBox: {
     display: "flex",
-    flexFlow: "column nowrap",
-    justifyContent: "center",
+    flexDirection: "column",
     alignItems: "center",
-    margin: 1,
+    margin: 0,
     "&:hover": {
       cursor: "pointer",
     },
   },
   nodeIconBox: {
+    height: "50px",
+    width: "50px",
+    borderRadius: "50%",
+    border: "1px solid #5a5b61",
     display: "flex",
-    flexDirection: "row",
     justifyContent: "center",
-    padding: 1.5,
-    width: "fit-content",
-    height: "fit-content",
-    background: "transparent",
-    border: 1,
-    borderColor: "#5a5b61",
-    borderRadius: 8,
-    marginBottom: "auto",
+    alignItems: "center",
+    padding: "12px",
   },
-  nodeTextContainer: {
-    textAlign: "center",
+  nodeIcon: {
+    height: "100%",
+    width: "100%",
   },
   nodeName: {
     color: "#E9EAF1",
     fontWeight: 600,
-    fontSize: 16,
+    fontSize: "16px",
   },
   nodeService: {
     color: "#B6B7BE",
     fontWeight: 500,
-    fontSize: 14,
+    fontSize: "14px",
   },
 };


### PR DESCRIPTION
**What this PR does**:
1. Fix service name text style.
2. Fix margin between the node and the flow arrow line.
3. Fix rendering issue when using a non-default resource icon.

**Which issue(s) this PR fixes**:
Fixes #660 
Fixes #661 

Before:
![Screenshot 2022-12-02 at 16 05 53](https://user-images.githubusercontent.com/37577482/205318485-53e15480-39ba-4c18-b779-73cc69808faa.png)
![Screenshot 2022-12-02 at 16 06 40](https://user-images.githubusercontent.com/37577482/205318498-4d87ebf1-8302-4968-9ad7-f7b4bd8a4c71.png)

After:
![Screenshot 2022-12-02 at 16 03 44](https://user-images.githubusercontent.com/37577482/205318534-c7f4588d-ccc1-4de7-830f-fe9927e7bc0a.png)
![Screenshot 2022-12-02 at 16 03 29](https://user-images.githubusercontent.com/37577482/205318548-470a89e1-b23e-4c94-96d3-31de752862ce.png)