### PR TITLE
fix: spas table rows are clickable before data is loaded

### DIFF
--- a/web/src/features/search/components/SpanTable/SpanTable.tsx
+++ b/web/src/features/search/components/SpanTable/SpanTable.tsx
@@ -94,9 +94,10 @@ export function SpanTable({ filters = [], timeframe }: SpanTableProps) {
   }, [fetchMoreOnBottomReached, tableWrapper]);
 
   const onClick = (row: Row<TableSpan>) => {
-    window.open(
-      `${window.location.origin}/trace/${row.original.traceId}?spanId=${row.original.spanId}`
-    );
+    !isLoading &&
+      window.open(
+        `${window.location.origin}/trace/${row.original.traceId}?spanId=${row.original.spanId}`
+      );
   };
 
   return (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
prevents onClick navigation from a skeleton row in spans table 

**Which issue(s) this PR fixes**:
Fixes #678 

**Checklist**

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
