### PR TITLE
fix(ci): fixed assigning default project in bots prs

### DIFF
--- a/.github/workflows/add-issue-to-project.yaml
+++ b/.github/workflows/add-issue-to-project.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    if: ${{ !startsWith(env.USER_ID, 'BOT') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.4.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:
PR that created by bots will not be assigned to default project
