### PR TITLE
fix(sidebar): http route pointed to the wrong tag

### DIFF
--- a/web/src/features/search/components/TagSidebar/TagSidebar.tsx
+++ b/web/src/features/search/components/TagSidebar/TagSidebar.tsx
@@ -61,7 +61,7 @@ export const TagSidebar = ({
     },
     {
       title: "HTTP Route",
-      tag: "span.attributes.http.target",
+      tag: "span.attributes.http.route",
       isSearchable: true,
     },
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

fixed `HTTP Route` section in the sidebar, it pointed on the wrong tag

