### PR TITLE
feat: change span table layout to compact

### DIFF
--- a/web/src/features/search/components/SpanTable/SpanTable.tsx
+++ b/web/src/features/search/components/SpanTable/SpanTable.tsx
@@ -166,6 +166,7 @@ export function SpanTable({ filters = [], timeframe }: SpanTableProps) {
         }}
         muiTablePaperProps={{ sx: styles.tablePaper }}
         muiTableBodyRowProps={({ row }) => ({ onClick: () => onClick(row) })}
+        initialState={{ density: "compact" }}
       />
     </div>
   );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:

Changing the layout of the spans table to be more compact:
<img width="1243" alt="from" src="https://user-images.githubusercontent.com/24767098/207002666-2b8e8922-4668-4d0a-9178-edfd3b0b2a7e.png">

to:
<img width="1228" alt="to" src="https://user-images.githubusercontent.com/24767098/207002686-e17da7c3-761d-4c32-9686-e186d5e370bf.png">



## Which issue(s) this PR fixes:

Fixes https://github.com/epsagon/lupa/issues/753
