### PR TITLE
feat(trace-view): non default icons trace tags view

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -57,7 +57,7 @@ function getBasicAttributes(span: InternalSpan): Attributes {
 }
 
 function getSpanResourceType(span: Readonly<InternalSpan>): string {
-  const attr = { ...span.span.attributes };
+  const spanAttr = span.span.attributes;
 
   const resourceTypeSet = new Set<string>([
     "db.system",
@@ -66,7 +66,7 @@ function getSpanResourceType(span: Readonly<InternalSpan>): string {
   ]);
 
   for (const key of resourceTypeSet) {
-    if (attr[key]) return attr[key].toString();
+    if (spanAttr[key]) return spanAttr[key].toString();
   }
 
   return "";


### PR DESCRIPTION
## What this PR does:
Use non-default icons for spans in the tags view panel, according to the following fields:
```
"db.system", "db.type", "messaging.system"
```

## Which issue(s) this PR fixes:

Fixes #496 
