### PR TITLE
fix(trace graph): Fix graph nodes grouping

### DIFF
--- a/web/src/features/trace/components/TraceGraph/utils/layout.ts
+++ b/web/src/features/trace/components/TraceGraph/utils/layout.ts
@@ -136,15 +136,13 @@ const getGraphNodeData = (s: Readonly<InternalSpan>): GraphNodeData => {
   ]);
   const graphNodeData: GraphNodeData = {
     id: "",
-    name: "",
+    name: spanAttributes["service.name"].toString(),
     image: "",
-    type: "",
+    type: "service",
   };
-  let hasFoundType = false;
   for (const [serviceTypeKey, serviceNameKeys] of serviceTypeToNamesMap) {
     const serviceType = spanAttributes[serviceTypeKey];
     if (serviceType) {
-      hasFoundType = true;
       for (const name of serviceNameKeys) {
         const serviceName = spanAttributes[name];
         if (serviceName) {
@@ -157,10 +155,7 @@ const getGraphNodeData = (s: Readonly<InternalSpan>): GraphNodeData => {
       break;
     }
   }
-  if (!hasFoundType) {
-    graphNodeData.name = spanAttributes["service.name"].toString();
-    graphNodeData.type = "service";
-  }
+
   graphNodeData.id = `${graphNodeData.name}-${graphNodeData.type}`;
   return graphNodeData;
 };


### PR DESCRIPTION
## What this PR does:
Fix graph nodes build by changing the way we group the spans.
Changed the grouping to iterate over the possible service types (db, messaging) and check their existence in the span attributes (it was the opposite before). Also fixed some small issues in the grouping logic.

## Which issue(s) this PR fixes:
Fixes #771 

