### PR TITLE
feat(goreleaser): 777 add build info to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/amd64
-      - --build-arg BUILD_INFO={{ git describe --tags }}
+      - --build-arg=BUILD_INFO={{ .Summary }}
     goarch: amd64
     goos: linux
     extra_files:
@@ -50,7 +50,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/arm64/v8
-      - --build-arg BUILD_INFO={{ git describe --tags }}
+      - --build-arg=BUILD_INFO={{ .Summary }}
     goarch: arm64
     goos: linux
     extra_files:
@@ -71,7 +71,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - --platform=linux/arm/v7
-      - --build-arg BUILD_INFO={{ git describe --tags }}
+      - --build-arg=BUILD_INFO={{ .Summary }}
     goarch: arm
     goarm: 7
     goos: linux


### PR DESCRIPTION

## What this PR does:
Adds the BUILD_INFO as arg to the all-in-one dockerfile. The BUILD_INFO will contain the current release & commit which can be viewed in the UI 

## Which issue(s) this PR fixes:
Fixes #777 

