### PR TITLE
refactor(trace-view): improve graph api to avoid empty state

### DIFF
--- a/web/src/features/trace/components/TraceGraph/TraceGraph.tsx
+++ b/web/src/features/trace/components/TraceGraph/TraceGraph.tsx
@@ -18,6 +18,7 @@ import { Box, CircularProgress, Stack } from "@mui/material";
 import {
   MouseEvent as ReactMouseEvent,
   memo,
+  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -31,9 +32,11 @@ import {
   useNodesState,
 } from "reactflow";
 
+import { InternalSpan } from "@/types/span";
+
 import { BasicEdge } from "./BasicEdge";
 import { BasicNode } from "./BasicNode";
-import { EdgeData, NodeData, TraceData, TraceGraphProps } from "./types";
+import { EdgeData, GraphNode, NodeData, TraceData } from "./types";
 import { createGraphLayout, spansToGraphData } from "./utils/layout";
 import {
   applyHoverEdgeStyle,
@@ -46,13 +49,21 @@ import {
 
 import "reactflow/dist/style.css";
 
+export interface TraceGraphProps {
+  spans: InternalSpan[];
+  initiallyFocusedSpanId: string | null;
+  onInitialNodeSelection: (node: GraphNode) => void;
+  onSelectedNodeChange: (node: GraphNode) => void;
+}
+
 const nodeTypes = { basicNode: BasicNode };
 const edgeTypes = { basicEdge: BasicEdge };
 
 const TraceGraphImpl = ({
-  setSelectedNode,
   spans,
   initiallyFocusedSpanId,
+  onInitialNodeSelection,
+  onSelectedNodeChange,
 }: TraceGraphProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [nodes, setNodes, onNodesChange] = useNodesState<NodeData>([]);
@@ -77,50 +88,58 @@ const TraceGraphImpl = ({
   useEffect(() => {
     setNodes(traceData.nodes);
     setEdges(traceData.edges);
-  }, [traceData]);
+  }, [traceData, setNodes, setEdges]);
+
+  const markSelectedNode = useCallback(
+    (
+      nodes: Node<NodeData>[],
+      edges: Edge<EdgeData>[],
+      selectedNode: Node<NodeData>
+    ) => {
+      const connectedEdges = getConnectedEdges([selectedNode], edges);
+      setNodes(
+        nodes.map((n: Node<NodeData>) =>
+          n.id === selectedNode.id
+            ? applySelectedNodeStyle(n)
+            : applyNormalNodeStyle(n)
+        )
+      );
+      setEdges(
+        edges.map((e: Edge<EdgeData>) =>
+          connectedEdges.includes(e)
+            ? applySelectedEdgeStyle(e)
+            : applyNormalEdgeStyle(e)
+        )
+      );
+    },
+    [setEdges, setNodes]
+  );
 
   useEffect(() => {
     if (!initiallyFocusedSpanId) {
       return;
     }
-
     for (const node of traceData.nodes) {
       const isSpanWithinNode = node.data.graphNode.spans.some(
         (span) => span.span.spanId === initiallyFocusedSpanId
       );
       if (isSpanWithinNode) {
         markSelectedNode(traceData.nodes, traceData.edges, node);
+        onInitialNodeSelection(node.data.graphNode);
         break;
       }
     }
-  }, [traceData]);
-
-  const markSelectedNode = (
-    nodes: Node<NodeData>[],
-    edges: Edge<EdgeData>[],
-    selectedNode: Node<NodeData>
-  ) => {
-    setSelectedNode(selectedNode.data.graphNode);
-    const connectedEdges = getConnectedEdges([selectedNode], edges);
-    setNodes(
-      nodes.map((n: Node<NodeData>) =>
-        n.id === selectedNode.id
-          ? applySelectedNodeStyle(n)
-          : applyNormalNodeStyle(n)
-      )
-    );
-    setEdges(
-      edges.map((e: Edge<EdgeData>) =>
-        connectedEdges.includes(e)
-          ? applySelectedEdgeStyle(e)
-          : applyNormalEdgeStyle(e)
-      )
-    );
-  };
+  }, [
+    traceData,
+    markSelectedNode,
+    initiallyFocusedSpanId,
+    onInitialNodeSelection,
+  ]);
 
   const onNodeClick = (event: ReactMouseEvent, node: Node<NodeData>) => {
     event.stopPropagation();
     markSelectedNode(nodes, edges, node);
+    onSelectedNodeChange(node.data.graphNode);
   };
 
   const onNodeMouseEnter = (event: ReactMouseEvent, node: Node<NodeData>) => {

--- a/web/src/features/trace/components/TraceGraph/types.ts
+++ b/web/src/features/trace/components/TraceGraph/types.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { Edge, Node } from "reactflow";
 
 import { InternalSpan } from "@/types/span";
@@ -39,12 +38,6 @@ export interface EdgeData {
   time: string;
   count: number;
   hasError: boolean;
-}
-
-export interface TraceGraphProps {
-  setSelectedNode: (node: GraphNode | null) => void;
-  spans: InternalSpan[];
-  initiallyFocusedSpanId: string | null;
 }
 
 export enum EdgeColor {

--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -17,7 +17,7 @@
 import ReactSplit, { SplitDirection } from "@devbookhq/splitter";
 import { Alert, Box, CircularProgress, Divider } from "@mui/material";
 import { Stack } from "@mui/system";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Params, useParams, useSearchParams } from "react-router-dom";
 
 import { Head } from "@/components/Head";
@@ -71,12 +71,14 @@ export const TraceView = () => {
     setLayuotSizes(allSizes);
   }
 
-  const handleSelectedNodeChange = (node: GraphNode | null) => {
+  const handleInitialNodeSelection = useCallback((node: GraphNode) => {
     setSelectedNode(node);
-    if (!node) {
-      setSelectedSpanId(null);
-    }
-  };
+  }, []);
+
+  const handleSelectedNodeChange = useCallback((node: GraphNode) => {
+    setSelectedNode(node);
+    setSelectedSpanId(null);
+  }, []);
 
   if (isLoading) {
     return (
@@ -121,9 +123,10 @@ export const TraceView = () => {
               divider={<Divider orientation="vertical" flexItem />}
             >
               <TraceGraph
-                setSelectedNode={handleSelectedNodeChange}
                 spans={trace}
                 initiallyFocusedSpanId={initiallyFocusedSpanId}
+                onInitialNodeSelection={handleInitialNodeSelection}
+                onSelectedNodeChange={handleSelectedNodeChange}
               />
 
               <SpanDetailsList


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
- Align TraceGraph API to “no empty state” approach by disabling the possibility to pass null as a selected node.
- Update dependency arrays to ensure no stale values during rerenders.
- Reset selected span when clicking on an already selected node.
