### PR TITLE
feat(trace-view): remove parent span icon from details list

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ArrowForward, ArrowForwardIosSharp } from "@mui/icons-material";
+import { ArrowForwardIosSharp } from "@mui/icons-material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import {
   Accordion,
@@ -89,17 +89,10 @@ export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {
             ...(expanded && styles.expandedAccordion),
           }}
         >
-          <Stack sx={styles.spanFlowIconsContainer}>
-            <ResourceIcon
-              name="defaultresourceicon"
-              style={styles.spanSourceIcon}
-            />
-            <ArrowForward style={styles.spanFlowArrowIcon} />
-            <ResourceIcon
-              name={getSpanResourceType(span)}
-              style={styles.spanDestIcon}
-            />
-          </Stack>
+          <ResourceIcon
+            name={getSpanResourceType(span)}
+            style={styles.spanIcon}
+          />
           <Stack>
             <Typography sx={styles.spanName}>{span.span.name}</Typography>
             <Typography sx={styles.spanTimes}>

--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/styles.ts
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/styles.ts
@@ -25,6 +25,10 @@ export const styles = {
     padding: "8px 8px 8px 25px",
     borderRadius: "8px",
     backgroundColor: "#1B1C21",
+    "& .MuiAccordionSummary-content": {
+      margin: 0,
+      alignItems: "center",
+    },
     "& .MuiAccordionSummary-expandIconWrapper.Mui-expanded": {
       transform: "rotate(90deg)",
     },
@@ -62,24 +66,10 @@ export const styles = {
     flex: "1",
     width: "1px",
   },
-  spanFlowIconsContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginRight: "17px",
-  },
-  spanSourceIcon: {
-    marginLeft: "22px",
+  spanIcon: {
     width: "22px",
     height: "22px",
-  },
-  spanFlowArrowIcon: {
-    fontSize: "16px",
-    margin: "0 8px",
-    color: "#96979E",
-  },
-  spanDestIcon: {
-    width: "22px",
-    height: "22px",
+    margin: "0 17px 0 23px",
   },
   spanName: {
     fontWeight: "700",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Removes the parent span icon from the span details list.

## Which issue(s) this PR fixes:
Fixes #792

![Screenshot 2022-12-17 at 18 28 16](https://user-images.githubusercontent.com/37577482/208251884-c8a68ba2-410c-46fb-86d2-1c2b1cc81561.png)
![Screenshot 2022-12-17 at 18 28 27](https://user-images.githubusercontent.com/37577482/208251885-0cd22c50-72a6-4872-92e1-b16193efc79d.png)
![Screenshot 2022-12-17 at 18 28 38](https://user-images.githubusercontent.com/37577482/208251886-e2da1dbb-abde-42c2-b30f-5f38f9b27a26.png)