### PR TITLE
fix(trace-view): order span details list by start time

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
@@ -15,6 +15,7 @@
  */
 
 import { Box } from "@mui/material";
+import { useMemo } from "react";
 
 import { InternalSpan } from "@/types/span";
 
@@ -27,11 +28,22 @@ interface SpanDetailsListProps {
   setSelectedSpanId: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
+function sortSpansByStartTime(spans: InternalSpan[]) {
+  return [...spans].sort((spanA, spanB) => {
+    return spanA.span.startTimeUnixNano - spanB.span.startTimeUnixNano;
+  });
+}
+
 export const SpanDetailsList = ({
   spans,
   selectedSpanId,
   setSelectedSpanId,
 }: SpanDetailsListProps) => {
+  const sortedSpans = useMemo(
+    () => spans && sortSpansByStartTime(spans),
+    [spans]
+  );
+
   const handleChange = (spanId: string, expanded: boolean) => {
     const nextSelectedSpanId = expanded ? spanId : null;
     setSelectedSpanId(nextSelectedSpanId);
@@ -39,8 +51,8 @@ export const SpanDetailsList = ({
 
   return (
     <Box sx={styles.container}>
-      {spans &&
-        spans.map((span) => (
+      {sortedSpans &&
+        sortedSpans.map((span) => (
           <SpanDetails
             key={span.span.spanId}
             span={span}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Orders spans in the span details list by their start time.

## Which issue(s) this PR fixes:
Fixes #825

Before:
![Screenshot 2022-12-18 at 11 36 15](https://user-images.githubusercontent.com/37577482/208291742-e4052d7e-384f-4ce8-b56d-2e42a5189e69.png)

After:
![Screenshot 2022-12-18 at 11 37 08](https://user-images.githubusercontent.com/37577482/208291743-385e8f2c-85b1-4628-b6e8-ded25abe9d90.png)
