### PR TITLE
fix: add license header to traceline component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
 
 Lupa is built from the ground up for modern applications. It is open-source and relies on open standards like OpenTelemetry. It is an easy-to-deploy scalable solution, that supports multiple storage options.
 
-Lupa is developed and maintained by the [Epsagon](https://epsagon.com/) group (acquired by Cisco Systems, Inc).
 We believe distributed tracing has an enormous amount of value for modern stacks, and yet presents many challenges like scale and usability.
 
 We are a highly dedicated group of developers, with years of experience in distributed tracing. Open-sourcing knowledge and engaging the community around tracing is our mission.

--- a/web/src/features/trace/components/TraceTimeline/LabeledList.js
+++ b/web/src/features/trace/components/TraceTimeline/LabeledList.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { Divider } from "@mui/material";
 import { common, grey } from "@mui/material/colors";
 

--- a/web/src/features/trace/components/TraceTimeline/TimelineViewer.js
+++ b/web/src/features/trace/components/TraceTimeline/TimelineViewer.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import _clamp from "lodash-es/clamp";
 import _mapValues from "lodash-es/mapValues";
 import { Component } from "react";

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/CanvasSpanGraph.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/CanvasSpanGraph.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import * as React from "react";
 
 import colorGenerator from "../../utils/color-generator.js";

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/GraphTicks.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/GraphTicks.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 export default function GraphTicks(props) {
   const { numTicks } = props;
   const ticks = [];

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/Scrubber/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/Scrubber/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import cx from "classnames";
 
 import { theme } from "@/styles";

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/Scrubber/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/Scrubber/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .Scrubber--handleExpansion {
   cursor: col-resize;
   fill-opacity: 0;

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/TickLabels.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/TickLabels.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { formatDuration } from "../../utils/date.js";
 
 export default function TickLabels(props) {

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/ViewingLayer/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/ViewingLayer/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import cx from "classnames";
 import * as React from "react";
 

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/ViewingLayer/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/ViewingLayer/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .ViewingLayer {
   cursor: vertical-text;
   position: relative;

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import * as React from "react";
 
 import CanvasSpanGraph from "./CanvasSpanGraph.js";

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/render-into-canvas.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/render-into-canvas.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 export const BG_COLOR = "#1B1C21";
 export const ITEM_ALPHA = 0.8;
 export const MIN_ITEM_HEIGHT = 2;

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/SpanGraph/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .CanvasSpanGraph {
   height: 60px;
   position: absolute;

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { Button } from "@mui/material";
 import dayjs from "dayjs";
 

--- a/web/src/features/trace/components/TraceTimeline/TracePageHeader/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TracePageHeader/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .TracePageHeader--titleRow {
   /*align-items: center;*/
   /*background-color: #fff;*/

--- a/web/src/features/trace/components/TraceTimeline/TraceTimeline.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimeline.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { useMemo, useState } from "react";
 
 import TimelineViewer from "./TimelineViewer";

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/Ticks.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/Ticks.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { formatDuration } from "../utils/date.js";
 
 export default function Ticks(props) {

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { KeyboardArrowRight } from "@mui/icons-material";
 import { Tooltip } from "@mui/material";
 import React from "react";

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import cx from "classnames";
 import * as React from "react";
 

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/TimelineViewingLayer.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import cx from "classnames";
 import * as React from "react";
 

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import * as React from "react";
 
 import Ticks from "../Ticks.js";

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineHeaderRow/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .TimelineHeaderRow {
   background: #2b2d32;
   height: 24px;

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineRow.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/TimelineRow.js
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 function TimelineRow(props) {
   const { children, className = "", ...rest } = props;
   return (

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/ListView/Positions.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/ListView/Positions.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Keeps track of the height and y-position for anything sequenctial where
  * y-positions follow one-after-another and can be derived from the height of

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/ListView/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/ListView/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import * as React from "react";
 
 import Positions from "./Positions.js";

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBar.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBar.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { Tooltip } from "@mui/material";
 import { compose, onlyUpdateForKeys, withProps, withState } from "recompose";
 

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBarRow.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBarRow.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import * as React from "react";
 import IoArrowRightA from "react-icons/lib/io/arrow-right-a";
 

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanTreeOffset.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanTreeOffset.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { KeyboardArrowDown, KeyboardArrowRight } from "@mui/icons-material";
 import cx from "classnames";
 import { PureComponent } from "react";

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import cx from "classnames";
 import * as React from "react";
 

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .VirtualizedTraceView--spans {
   padding-top: 24px;
 }

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { PureComponent } from "react";
 
 // eslint-disable-next-line import/no-cycle

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .flex-row {
   display: flex;
   flex: 0 1 auto;

--- a/web/src/features/trace/components/TraceTimeline/TreeNode.js
+++ b/web/src/features/trace/components/TraceTimeline/TreeNode.js
@@ -1,3 +1,15 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 export default class TreeNode {
   static iterFunction(fn, depth = 0) {
     return (node) => fn(node.value, node, depth);

--- a/web/src/features/trace/components/TraceTimeline/index.js
+++ b/web/src/features/trace/components/TraceTimeline/index.js
@@ -1,1 +1,14 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 export { TraceTimeline } from "./TraceTimeline";

--- a/web/src/features/trace/components/TraceTimeline/styles.css
+++ b/web/src/features/trace/components/TraceTimeline/styles.css
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .Tracepage--headerSection {
   position: absolute;
   width: 100%;

--- a/web/src/features/trace/components/TraceTimeline/utils/DraggableManager.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/DraggableManager.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import _get from "lodash-es/get";
 
 const LEFT_MOUSE_BUTTON = 0;

--- a/web/src/features/trace/components/TraceTimeline/utils/ScrollManager.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/ScrollManager.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Returns `{ isHidden: true, ... }` if one of the parents of `span` is
  * collapsed, e.g. has children hidden.

--- a/web/src/features/trace/components/TraceTimeline/utils/Tween.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/Tween.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import ease from "tween-functions";
 
 export default class Tween {

--- a/web/src/features/trace/components/TraceTimeline/utils/color-generator.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/color-generator.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const COLORS_HEX = ["#548CFF", "#A3E4DB", "#6E3CBC", "#4ABB8C", "#A2D2FF"];
 
 function mapHexToRgb(colors) {

--- a/web/src/features/trace/components/TraceTimeline/utils/date.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/date.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import dayjs, { duration as _duration } from "dayjs";
 import _ from "lodash-es";
 

--- a/web/src/features/trace/components/TraceTimeline/utils/index.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/index.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 /**
  * Given a range (`min`, `max`) and factoring in a zoom (`viewStart`, `viewEnd`)
  * a function is created that will find the position of a sub-range (`start`, `end`).

--- a/web/src/features/trace/components/TraceTimeline/utils/keyboard-mappings.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/keyboard-mappings.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 export default {
   panLeft: { binding: ["a", "left"], label: "Pan left" },
   panLeftFast: {

--- a/web/src/features/trace/components/TraceTimeline/utils/keyboard-shortcuts.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/keyboard-shortcuts.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Combokeys from "combokeys";
 
 import keyboardMappings from "./keyboard-mappings.js";

--- a/web/src/features/trace/components/TraceTimeline/utils/process.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/process.js
@@ -1,2 +1,15 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 export const getProcessServiceName = (proc) => proc.serviceName;
 export const getProcessTags = (proc) => proc.tags;

--- a/web/src/features/trace/components/TraceTimeline/utils/scroll-page.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/scroll-page.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import Tween from "./Tween.js";
 
 const DURATION_MS = 350;

--- a/web/src/features/trace/components/TraceTimeline/utils/span-ancestor-ids.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/span-ancestor-ids.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import _find from "lodash-es/find";
 import _get from "lodash-es/get";
 

--- a/web/src/features/trace/components/TraceTimeline/utils/span.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/span.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import sortBy from "lodash-es/sortBy";
 
 import { getProcessServiceName } from "./process.js";

--- a/web/src/features/trace/components/TraceTimeline/utils/trace.js
+++ b/web/src/features/trace/components/TraceTimeline/utils/trace.js
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2017 Uber Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import isEqual from "lodash-es/isEqual";
 
 import TreeNode from "../TreeNode.js";


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Add license header to timeline components, and change readme to be compatible for Cisco's review.


## Checklist

- [x] Documentation added