### PR TITLE
fix(span-details): span error message improvements

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanErrorDetails/SpanErrorDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanErrorDetails/SpanErrorDetails.tsx
@@ -44,7 +44,7 @@ export const SpanErrorDetails = ({ errorMessage }: SpanErrorDetailsProps) => {
         sx={expanded ? styles.textContainerExpanded : styles.textContainer}
       >
         <Typography sx={styles.typography}>
-          {errorMessage ? errorMessage : "No Error Message Found"}
+          {errorMessage ? errorMessage : "No error message found"}
         </Typography>
       </Box>
       {showButton && (
@@ -55,7 +55,7 @@ export const SpanErrorDetails = ({ errorMessage }: SpanErrorDetailsProps) => {
             sx={styles.readMoreButton}
             disableRipple
           >
-            {expanded ? "Show Less" : "Read More"}
+            {expanded ? "Show Less" : "Show More"}
           </Button>
         </Box>
       )}

--- a/web/src/features/trace/components/SpanDetailsList/SpanErrorDetails/styles.ts
+++ b/web/src/features/trace/components/SpanDetailsList/SpanErrorDetails/styles.ts
@@ -22,7 +22,7 @@ const textContainer = {
 
 export const styles = {
   mainContainer: {
-    background: "#0B0B0D",
+    background: "#141414",
     borderLeft: "1px solid #EF5854",
   },
   textContainer,


### PR DESCRIPTION

## What this PR does:
1. Fixed no error message text in span details view.
2. Changed background color of error details in span details view (after discussed with @adva-cisco )
3. Changed "Read More" to "Show More"

## Which issue(s) this PR fixes:
Fixes #779