### PR TITLE
refactor: update start time format to include ms

### DIFF
--- a/web/src/features/search/components/SpanTable/SpanTable.tsx
+++ b/web/src/features/search/components/SpanTable/SpanTable.tsx
@@ -24,7 +24,7 @@ import { useEffect, useRef, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 import { InternalSpan } from "@/types/span";
-import { formatDateAsDateTime, nanoSecToMs } from "@/utils/format";
+import { formatNanoAsMsDateTime } from "@/utils/format";
 
 import { useSpansQuery } from "../../api/spanQuery";
 import { SearchFilter } from "../../types/common";
@@ -113,7 +113,7 @@ export function SpanTable({
         id: span.spanId,
         traceId: span.traceId,
         spanId: span.spanId,
-        startTime: formatDateAsDateTime(nanoSecToMs(span.startTimeUnixNano)),
+        startTime: formatNanoAsMsDateTime(span.startTimeUnixNano),
         duration: externalFields.durationNano,
         name: span.name,
         status: span.status.code,

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -20,7 +20,7 @@ export const formatDateAsDateTime = (
   date: Date | number,
   { showMs = false, showSec = true } = {}
 ) => {
-  const pattern = `PP, HH:mm${showSec ? ":ss" : ""}${
+  const pattern = `PP HH:mm${showSec ? ":ss" : ""}${
     showSec && showMs ? ".SSS" : ""
   }`;
   return format(date, pattern);


### PR DESCRIPTION


## What this PR does:

adding ms to the start time in the spans table
It is affecting also the trace view since we removed the `,` between the date and the time

<img width="490" alt="Screenshot 2022-12-26 at 19 18 50" src="https://user-images.githubusercontent.com/24767098/209571208-a0a7cd2c-fd52-49fb-86c9-1becfd086860.png">



## Which issue(s) this PR fixes:

Fixes https://github.com/epsagon/lupa/issues/849

