### PR TITLE
fix: Tag values selector minor css fixes

### DIFF
--- a/web/src/features/search/components/TagValuesSelector/styles.ts
+++ b/web/src/features/search/components/TagValuesSelector/styles.ts
@@ -40,6 +40,8 @@ export const styles: Record<string, SxProps<Theme>> = {
   checkboxList: {
     marginRight: "-16px",
     marginLeft: "-16px",
+    paddingBottom: "0",
+    "&:empty, &:first-child": { paddingTop: "0px" },
   },
   valueLabel: {
     direction: "rtl",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Fix the padding of the options list:
1. top is zero if first child or empty
2. bottom is always 0 (since the accordion summary has bottom padding)
## Which issue(s) this PR fixes:

Fixes #853

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
