### PR TITLE
fix(spans-search): hide clear filters btn when no filters applied

### DIFF
--- a/web/src/features/search/components/SearchBar/SearchBar.tsx
+++ b/web/src/features/search/components/SearchBar/SearchBar.tsx
@@ -85,15 +85,17 @@ export function SearchBar({
             />
           ))}
         </Stack>
-        <Stack direction="row" sx={styles.clear}>
-          <Divider
-            orientation="vertical"
-            sx={{ borderColor: theme.palette.grey[700], marginRight: "13px" }}
-          />
-          <IconButton onClick={onClearFilters} size="small">
-            <Close fontSize="inherit" />
-          </IconButton>
-        </Stack>
+        {filters.length > 0 && (
+          <Stack direction="row" sx={styles.clear}>
+            <Divider
+              orientation="vertical"
+              sx={{ borderColor: theme.palette.grey[700], marginRight: "13px" }}
+            />
+            <IconButton onClick={onClearFilters} size="small">
+              <Close fontSize="inherit" />
+            </IconButton>
+          </Stack>
+        )}
       </Stack>
     </Paper>
   );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:

hides the clear all filters button when there are no filters applied

## Which issue(s) this PR fixes:

Fixes #914

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
