### PR TITLE
feat: add start_time and end_time indices

### DIFF
--- a/lupa-otelcol/exporter/sqliteexporter/migrations/00_init_schema.up.sql
+++ b/lupa-otelcol/exporter/sqliteexporter/migrations/00_init_schema.up.sql
@@ -97,3 +97,6 @@ ON spans (start_time_unix_nano);
 
 CREATE INDEX IF NOT EXISTS end_time_index
 ON spans (end_time_unix_nano);
+
+CREATE INDEX IF NOT EXISTS duration_index
+ON spans (duration);


### PR DESCRIPTION
## What this PR does:
Adding indices definitions for start_time_unix_nano and end_time_unix_nano in the spans table

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/110758729/210564489-76b2f601-9b27-4725-8b8c-9cbc7b2c0464.png">


## Which issue(s) this PR fixes:

Fixes #918 

