### PR TITLE
fix: 952 trace view no specific span context when having too many spans

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -24,7 +24,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { ResourceIcon } from "@/components/Elements/ResourceIcon";
 import { Attributes, InternalSpan, StatusCode } from "@/types/span";
@@ -55,17 +55,14 @@ function getBasicAttributes(span: InternalSpan): Attributes {
 }
 
 export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {
+  const accordionRef = useRef<HTMLDivElement>(null);
   const basicAttributes = useMemo(() => getBasicAttributes(span), [span]);
   const X_DIVIDER = "|";
-  const spanID = span.span.spanId;
   const hasError: boolean = span.span.status.code === StatusCode.Error;
+
   useEffect(() => {
-    const element = expanded ? document.getElementById(spanID) : undefined;
-    if (element) {
-      element.scrollIntoView({
-        behavior: "auto",
-        block: "start",
-      });
+    if (expanded && accordionRef.current) {
+      accordionRef.current.scrollIntoView();
     }
   }, []);
 
@@ -83,7 +80,7 @@ export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {
         </Box>
       )}
       <Accordion
-        id={spanID}
+        ref={accordionRef}
         expanded={expanded}
         onChange={(_, expanded) => onChange(expanded)}
         disableGutters={true}


### PR DESCRIPTION
## What this PR does:
Added scrolling to specific span context.
Checked by: `http://localhost:3000/trace/30f4eed2bafe962b859c6a1fa4e62d37?spanId=dafe148a3a0c23bf`
With data from `Elastic`
## Which issue(s) this PR fixes:
Sometimes, after opening a span from the span search page, the span is expanded but not shown because there're too many spans belonging to the specific service. 
Fixes #952 
