### PR TITLE
fix: loading indicator zindex issue

### DIFF
--- a/web/src/features/search/components/SpanTable/styles.ts
+++ b/web/src/features/search/components/SpanTable/styles.ts
@@ -29,7 +29,14 @@ const newRowAnimation = keyframes`
  `;
 
 const styles: { [name: string]: CSSProperties } = {
-  progress: { margin: 0, position: "absolute", top: 45, right: 0, left: 0 },
+  progress: {
+    margin: 0,
+    position: "absolute",
+    top: 45,
+    right: 0,
+    left: 0,
+    zIndex: 1,
+  },
   container: { minHeight: 0, position: "relative", borderRadius: "8px" },
   tablePaper: { display: "flex", maxHeight: "100%" },
   tableContainer: { borderRadius: "8px" },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Show the table loading indicator when loading
## Which issue(s) this PR fixes:

Fixes #1034

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
