### PR TITLE
fix: added cache clearing behavior to refresh

### DIFF
--- a/web/src/features/search/components/RefreshButton/RefreshButton.tsx
+++ b/web/src/features/search/components/RefreshButton/RefreshButton.tsx
@@ -47,7 +47,7 @@ export function RefreshButton() {
   const filtersState = useSpanSearchStore((state) => state.filtersState);
   const sortState = useSpanSearchStore((state) => state.sortState);
 
-  const { isFetching } = useSpansQuery({
+  const { isFetching, remove: clearSpansQuery } = useSpansQuery({
     timeframe: timeframeState.currentTimeframe,
     filters: filtersState.filters,
     sort: sortState.sort,
@@ -82,6 +82,7 @@ export function RefreshButton() {
           timeframeState.currentTimeframe.endTimeUnixNanoSec
         );
 
+    clearSpansQuery();
     document.dispatchEvent(new Event("refresh"));
     setIsRefreshing(true);
   };


### PR DESCRIPTION
Added cache clearing behavior to refresh button when clicked, this makes sure that the query is refetched even if the timeframe didn't change

fixes #1223 