### PR TITLE
fix: removed timestamp set on custom timeframe cancelled in span search

### DIFF
--- a/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
+++ b/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
@@ -57,9 +57,6 @@ export const TimeFrameSelector = () => {
 
   const handleCancel = () => {
     setIsSelected(previousSelected);
-    timeframeState.setRelativeTimeframe(
-      timeframeState.currentTimeframe.startTimeUnixNanoSec
-    );
     setOpen(false);
   };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Removes timestamp state update on custom timestamp cancellation

## Which issue(s) this PR fixes:

Fixes #993 

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
