### PR TITLE
fix: add missing highlight to tag filter values

### DIFF
--- a/web/src/features/search/components/FilterBuilder/AutoCompleteValueSelector.tsx
+++ b/web/src/features/search/components/FilterBuilder/AutoCompleteValueSelector.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useState } from "react";
+import Highlighter from "react-highlight-words";
 import { useDebounce } from "use-debounce";
 
 import { formatNumber } from "@/utils/format";
@@ -128,14 +129,19 @@ export const AutoCompleteValueSelector = ({
           sx={styles.selectValueInput}
         />
       )}
-      renderOption={(props, option) => (
+      renderOption={(props, option, state) => (
         <ListItem {...props}>
           <Stack
-            sx={{ width: "100%" }}
+            sx={styles.selectValueResult}
             direction="row"
             justifyContent="space-between"
           >
-            <Typography>{option.value}</Typography>
+            <Highlighter
+              highlightClassName="valueLabelHighlight"
+              searchWords={state.inputValue.toLowerCase().split(" ")}
+              autoEscape={true}
+              textToHighlight={option.value.toString()}
+            />
             <Typography>{formatNumber(option.count)}</Typography>
           </Stack>
         </ListItem>

--- a/web/src/features/search/components/FilterBuilder/styles.ts
+++ b/web/src/features/search/components/FilterBuilder/styles.ts
@@ -53,6 +53,14 @@ export const styles = {
       },
     },
   },
+  selectValueResult: {
+    width: "100%",
+    ".valueLabelHighlight": {
+      backgroundColor: primaryActionColors.primaryClicked,
+      fontWeight: 900,
+      color: "white",
+    },
+  },
   textValueInput: {
     "& .MuiInputBase-root": {
       paddingRight: "unset",


### PR DESCRIPTION
## What this PR does:

Add missing highlight to tag filter values
<img width="583" alt="image" src="https://user-images.githubusercontent.com/24767098/213451236-8acadc72-2bb4-44aa-bb4e-50897a43a774.png">


## Which issue(s) this PR fixes:

Fixes https://github.com/epsagon/lupa/issues/1170
