### PR TITLE
fix: fetching spans with empty string value in filter

### DIFF
--- a/plugin/spanreader/es/utils/filter_factory.go
+++ b/plugin/spanreader/es/utils/filter_factory.go
@@ -130,7 +130,7 @@ func createEqualsFilter(f model.KeyValueFilter) (*types.QueryContainerBuilder, e
 
 	m := map[types.Field]*types.MatchPhraseQueryBuilder{}
 
-	m[types.Field(f.Key)] = types.NewMatchPhraseQueryBuilder().Query(fmt.Sprintf("%+v", f.Value)) // TODO hacky, should be better typing with PB request
+	m[types.Field(f.Key)] = types.NewMatchPhraseQueryBuilder().Query(fmt.Sprintf("%+v", f.Value))
 
 	return qc.MatchPhrase(m), nil
 }
@@ -153,7 +153,16 @@ func createInFilter(f model.KeyValueFilter) (*types.QueryContainerBuilder, error
 	for _, v := range sliceVal {
 		m := map[types.Field]*types.MatchPhraseQueryBuilder{}
 
-		m[types.Field(f.Key)] = types.NewMatchPhraseQueryBuilder().Query(fmt.Sprintf("%+v", v))
+		if vStr, ok := v.(string); ok {
+			if vStr == "" {
+				key := fmt.Sprintf("%s.keyword", f.Key)
+				m[types.Field(key)] = types.NewMatchPhraseQueryBuilder().Query("")
+			} else {
+				m[types.Field(f.Key)] = types.NewMatchPhraseQueryBuilder().Query(fmt.Sprintf("%s", v))
+			}
+		} else {
+			m[types.Field(f.Key)] = types.NewMatchPhraseQueryBuilder().Query(fmt.Sprintf("%+v", v))
+		}
 
 		shouldQueriesArray = append(shouldQueriesArray, m)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Fixes fetching spans from elasticsearch with filters containing empty strings

## Which issue(s) this PR fixes:

Fixes #1123 

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
