### PR TITLE
fix: return nano second to the user instead of ms for filters and tag values

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,6 +63,7 @@ func NewAPI(logger *zap.Logger, config config.Config, sr *spanreader.SpanReader)
 func newRouter(logger *zap.Logger, config config.Config) *gin.Engine {
 	setGinMode(config)
 	router := gin.New()
+	gin.EnableJsonDecoderUseNumber()
 	return router
 }
 

--- a/plugin/spanreader/es/tagscontroller/tags_controller_test.go
+++ b/plugin/spanreader/es/tagscontroller/tags_controller_test.go
@@ -223,7 +223,7 @@ func Test_HandleTimestamp_Values(t *testing.T) {
 
 	// Act
 	uut := tagsController{}
-	result, err := uut.parseGetTagsValuesResponseBody(body)
+	result, err := uut.parseGetTagsValuesResponseBody(body, convertTimestampsFromMilliToNano)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/spanreader/es/utils/filter_factory_test.go
+++ b/plugin/spanreader/es/utils/filter_factory_test.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"encoding/json"
-	"fmt"
 	"oss-tracing/pkg/model"
 	"testing"
 
@@ -140,12 +139,12 @@ func TestMultiMustNotFilters(t *testing.T) {
 		{
 			Key:      "resource.attributes.service.name",
 			Operator: "not_in",
-			Value:    []string{"demo-server"},
+			Value:    []interface{}{"demo-server"},
 		},
 		{
 			Key:      "span.name",
 			Operator: "not_in",
-			Value:    []string{"ExecuteRequest"},
+			Value:    []interface{}{"ExecuteRequest"},
 		},
 	}
 
@@ -213,6 +212,5 @@ func TestTimestampsConversion(t *testing.T) {
 	assert.Nil(t, err)
 	queryJson, err := json.Marshal(query.Build())
 	assert.Nil(t, err)
-	fmt.Println(string(queryJson))
 	assert.JSONEq(t, expectedJson, string(queryJson))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Convert the return milli seconds to nano seconds of the duration/ start time /end time:
1. In IN/NOT_IN operators
2. as the returned values of tag values API
## Which issue(s) this PR fixes:

Fixes #<issue number>

## Checklist

- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
