### PR TITLE
feat(trace-view): add parent id to spans' details list

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -42,10 +42,9 @@ export interface SpanDetailsProps {
 }
 
 function getBasicAttributes(span: InternalSpan): Attributes {
-  return {
+  const returnAttributes: Attributes = {
     service_name: span.resource.attributes["service.name"],
     name: span.span.name,
-    parent_id: span.span.parentSpanId || "",
     status: span.span.status.code,
     kind: span.span.kind,
     duration: formatDurationAsMs(span.externalFields.durationNano),
@@ -53,6 +52,9 @@ function getBasicAttributes(span: InternalSpan): Attributes {
     span_id: span.span.spanId,
     trace_id: span.span.traceId,
   };
+  span.span.parentSpanId &&
+    (returnAttributes["parent_span_id"] = span.span.parentSpanId);
+  return returnAttributes;
 }
 
 export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {


### PR DESCRIPTION
## What this PR does:
Adds parent Id to spans' details list

## Which issue(s) this PR fixes:
Fixes #1126

## Example:
span-2 is the child of span-1

![image](https://user-images.githubusercontent.com/89512916/214572291-9f577401-a60d-46cb-b1f9-98833b73cbea.png)

![image](https://user-images.githubusercontent.com/89512916/214572581-811e224f-b1a5-4242-861d-42c4a1c311c6.png)

