### PR TITLE
feat(trace-view): span context focus on timeline click

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -67,7 +67,7 @@ export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {
     if (expanded && accordionRef.current) {
       accordionRef.current.scrollIntoView();
     }
-  }, []);
+  }, [expanded]);
 
   return (
     <Box

--- a/web/src/features/trace/components/TraceTimeline/TimelineViewer.js
+++ b/web/src/features/trace/components/TraceTimeline/TimelineViewer.js
@@ -193,6 +193,7 @@ class TimelineViewer extends Component {
       traceState,
       addHoverIndentGuideId,
       selectedSpanId,
+      setSelectedSpanId,
     } = this.props;
     const { viewRange, headerHeight } = this.state;
 
@@ -228,6 +229,7 @@ class TimelineViewer extends Component {
               childrenToggle={childrenToggle}
               addHoverIndentGuideId={addHoverIndentGuideId}
               selectedSpanId={selectedSpanId}
+              setSelectedSpanId={setSelectedSpanId}
             />
           </section>
         )}

--- a/web/src/features/trace/components/TraceTimeline/TraceTimeline.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimeline.js
@@ -17,7 +17,7 @@ import { useMemo, useState } from "react";
 import TimelineViewer from "./TimelineViewer";
 import { transformTraceData } from "./utils/trace";
 
-export function TraceTimeline({ trace, selectedSpanId }) {
+export function TraceTimeline({ trace, selectedSpanId, setSelectedSpanId }) {
   const [traceState, setTraceState] = useState({
     childrenHiddenIDs: new Set(),
     detailStates: new Map(),
@@ -94,6 +94,7 @@ export function TraceTimeline({ trace, selectedSpanId }) {
     <TimelineViewer
       trace={transformedTrace}
       selectedSpanId={selectedSpanId}
+      setSelectedSpanId={setSelectedSpanId}
       setColumnWidth={setColumnWidth}
       removeHoverIndentGuideId={removeHoverIndentGuideId}
       setTrace={setTrace}

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBarRow.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/SpanBarRow.js
@@ -57,6 +57,7 @@ export default class SpanBarRow extends React.PureComponent {
       removeHoverIndentGuideId,
       addHoverIndentGuideId,
       selectedSpanId,
+      setSelectedSpanId,
     } = this.props;
     const { duration, hasChildren: isParent, operationName, process } = span;
     const serviceName = process.serviceName;
@@ -92,6 +93,7 @@ export default class SpanBarRow extends React.PureComponent {
           ${isDetailExpanded ? "is-expanded" : ""}
           ${selectedSpanId === span.spanID ? "is-active" : ""}
         `}
+        onClick={() => setSelectedSpanId(span.spanID)}
       >
         <TimelineRow.Cell className="span-name-column" width={columnDivision}>
           <div className="span-name-wrapper">

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/VirtualizedTraceView/index.js
@@ -272,7 +272,7 @@ class VirtualizedTraceViewImpl extends React.Component {
         };
       }
     }
-    const { selectedSpanId } = this.props;
+    const { selectedSpanId, setSelectedSpanId } = this.props;
     return (
       <div
         className="VirtualizedTraceView--row"
@@ -298,6 +298,7 @@ class VirtualizedTraceViewImpl extends React.Component {
           traceStartTime={trace.startTime}
           span={span}
           selectedSpanId={selectedSpanId}
+          setSelectedSpanId={setSelectedSpanId}
         />
       </div>
     );

--- a/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/index.js
+++ b/web/src/features/trace/components/TraceTimeline/TraceTimelineViewer/index.js
@@ -42,6 +42,7 @@ class TraceTimelineViewerImpl extends PureComponent {
       childrenToggle,
       addHoverIndentGuideId,
       selectedSpanId,
+      setSelectedSpanId,
       ...rest
     } = this.props;
     const { trace } = rest;
@@ -69,6 +70,7 @@ class TraceTimelineViewerImpl extends PureComponent {
           removeHoverIndentGuideId={removeHoverIndentGuideId}
           addHoverIndentGuideId={addHoverIndentGuideId}
           selectedSpanId={selectedSpanId}
+          setSelectedSpanId={setSelectedSpanId}
         />
       </div>
     );

--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -71,11 +71,11 @@ export const TraceView = () => {
     setLayuotSizes(allSizes);
   }
 
-  const handleInitialNodeSelection = useCallback((node: GraphNode) => {
+  const handleAutoSelectedNodeChange = useCallback((node: GraphNode) => {
     setSelectedNode(node);
   }, []);
 
-  const handleSelectedNodeChange = useCallback((node: GraphNode) => {
+  const handleGraphNodeClick = useCallback((node: GraphNode) => {
     setSelectedNode(node);
     setSelectedSpanId(null);
   }, []);
@@ -124,11 +124,11 @@ export const TraceView = () => {
             >
               <TraceGraph
                 spans={trace}
+                selectedSpanId={selectedSpanId}
                 initiallyFocusedSpanId={initiallyFocusedSpanId}
-                onInitialNodeSelection={handleInitialNodeSelection}
-                onSelectedNodeChange={handleSelectedNodeChange}
+                onAutoSelectedNodeChange={handleAutoSelectedNodeChange}
+                onGraphNodeClick={handleGraphNodeClick}
               />
-
               <SpanDetailsList
                 spans={selectedNode?.spans}
                 selectedSpanId={selectedSpanId}
@@ -142,7 +142,11 @@ export const TraceView = () => {
             sx={styles.timelineWrapper}
             divider={<Divider orientation="vertical" flexItem />}
           >
-            <TraceTimeline trace={trace} selectedSpanId={selectedSpanId} />
+            <TraceTimeline
+              trace={trace}
+              selectedSpanId={selectedSpanId}
+              setSelectedSpanId={setSelectedSpanId}
+            />
           </Stack>
         </ReactSplit>
       </ReactSplit>


### PR DESCRIPTION
## What this PR does:
Clicking on a span row in the trace timeline will now:
1. Select the graph node that contains the selected span.
2. Scroll to view the selected span in the right pane span list.

https://user-images.githubusercontent.com/37577482/214849334-fe46a59b-8e63-4a29-9b67-f4d44567badb.mov

## Which issue(s) this PR fixes:
Fixes #1089
Fixes #1009 