### PR TITLE
fix: remove Events and Links serialization

### DIFF
--- a/model/internalspan/v1/internal_span.go
+++ b/model/internalspan/v1/internal_span.go
@@ -61,9 +61,9 @@ type Span struct {
 	EndTimeUnixNano        uint64       `json:"endTimeUnixNano"`
 	Attributes             Attributes   `json:"attributes"`
 	DroppedAttributesCount uint32       `json:"droppedAttributesCount"`
-	Events                 []*SpanEvent `json:"events"`
+	Events                 []*SpanEvent `json:"-"`
 	DroppedEventsCount     uint32       `json:"droppedEventsCount"`
-	Links                  []*SpanLink  `json:"links"`
+	Links                  []*SpanLink  `json:"-"`
 	DroppedLinksCount      uint32       `json:"droppedLinksCount"`
 	Status                 *SpanStatus  `json:"status"`
 }


### PR DESCRIPTION
This PR is temporary.

For now, don't serialize Events and Links since they can potentially cause ES indexing conflicts.
We don't use these fields anyway.