### PR TITLE
fix: get tags for nil fields

### DIFF
--- a/plugin/spanreader/sqlite/span_reader.go
+++ b/plugin/spanreader/sqlite/span_reader.go
@@ -138,14 +138,14 @@ func (sr *spanReader) GetAvailableTags(ctx context.Context, r tagsquery.GetAvail
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var tableKey, tagName, tagType string
-		err = rows.Scan(&tableKey, &tagName, &tagType)
+		sqliteTag := newSqliteTag()
+		err = rows.Scan(&sqliteTag.tableKey, &sqliteTag.tagName, &sqliteTag.tagType)
 		if err != nil {
 			sr.logger.Error("failed to get tag value", zap.Error(err))
 			continue
 		}
-		tag.Name = fmt.Sprintf("%s.%s", tableKey, tagName)
-		tag.Type = tagType
+		tag.Name = fmt.Sprintf("%s.%s", sqliteTag.getTableKey(), sqliteTag.getTagName())
+		tag.Type = sqliteTag.getTagType()
 		tags.Tags = append(tags.Tags, tag)
 	}
 	return &tags, nil

--- a/plugin/spanreader/sqlite/sqlite_tag.go
+++ b/plugin/spanreader/sqlite/sqlite_tag.go
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sqlitespanreader
+
+import "database/sql"
+
+type sqliteTag struct {
+	tableKey, tagName, tagType sql.NullString
+}
+
+func newSqliteTag() *sqliteTag {
+	return &sqliteTag{}
+}
+
+func (t *sqliteTag) getTableKey() string {
+	if t.tagType.Valid {
+		return t.tableKey.String
+	}
+	return ""
+}
+
+func (t *sqliteTag) getTagName() string {
+	if t.tagType.Valid {
+		return t.tagName.String
+	}
+	return ""
+}
+
+func (t *sqliteTag) getTagType() string {
+	if t.tagType.Valid {
+		return t.tagType.String
+	}
+	return ""
+}


### PR DESCRIPTION
## What this PR does:
changed types of variables for tag querying
@maorlx merge these changes to your brunch 
