### PR TITLE
fix(trace-view): truncate overflowing span names

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/SpanDetails.tsx
@@ -28,6 +28,7 @@ import {
 } from "@mui/material";
 import { MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 
+import { MiddleTruncatedTypography } from "@/components/Elements/MiddleTruncatedTypography";
 import { ResourceIcon } from "@/components/Elements/ResourceIcon";
 import { Attributes, InternalSpan, StatusCode } from "@/types/span";
 import { formatDurationAsMs, formatNanoAsMsDateTime } from "@/utils/format";
@@ -113,8 +114,11 @@ export const SpanDetails = ({ span, expanded, onChange }: SpanDetailsProps) => {
             name={getSpanResourceType(span)}
             style={styles.spanIcon}
           />
-          <Stack>
-            <Typography sx={styles.spanName}>{span.span.name}</Typography>
+          <Stack sx={styles.spanSummaryContainer}>
+            <MiddleTruncatedTypography
+              sx={styles.spanName}
+              text={span.span.name}
+            />
             <Typography sx={styles.spanTimes}>
               {basicAttributes.duration}{" "}
               <Box component={"span"} sx={styles.spanTimesDivider}>

--- a/web/src/features/trace/components/SpanDetailsList/SpanDetails/styles.ts
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetails/styles.ts
@@ -22,10 +22,11 @@ export const styles = {
   accordionSummary: {
     flexDirection: "row-reverse",
     height: "60px",
-    padding: "8px 8px 8px 25px",
+    padding: "8px 25px",
     borderRadius: "8px",
     backgroundColor: "#1B1C21",
     "& .MuiAccordionSummary-content": {
+      width: "100%",
       margin: 0,
       alignItems: "center",
     },
@@ -77,6 +78,9 @@ export const styles = {
     width: "22px",
     height: "22px",
     margin: "0 17px 0 23px",
+  },
+  spanSummaryContainer: {
+    overflow: "hidden",
   },
   spanName: {
     fontWeight: "700",


### PR DESCRIPTION
## What this PR does:
Truncates overflowing span names in the span details list (right pane).

<img width="472" alt="Screenshot 2023-02-05 at 18 33 22" src="https://user-images.githubusercontent.com/37577482/216831884-fa92b1bf-50e1-4619-96c1-385fd0a61b97.png">


## Which issue(s) this PR fixes:
Fixes #1075 
