### PR TITLE
fix(e2e-tests): Disabled e2e tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,10 +12,6 @@ queue_rules:
     conditions:
       - base=main
       - check-success=Wait for CI
-      - or: &E2ETests
-          - check-success=Wait E2E Tests
-          - check-neutral=Wait E2E Tests
-          - check-skipped=Wait E2E Tests
     batch_size: 5
     allow_inplace_checks: false
 


### PR DESCRIPTION


## What this PR does:
Disabling e2e tests workflow due to issue with Playwright browsers installation. See [here](https://github.com/epsagon/lupa/actions/runs/4102427619/jobs/7075670096)

