### PR TITLE
fix(span-table): hide loading indication in live mode

### DIFF
--- a/web/src/features/search/components/SpanTable/SpanTable.tsx
+++ b/web/src/features/search/components/SpanTable/SpanTable.tsx
@@ -183,7 +183,9 @@ export function SpanTable() {
 
   return (
     <div style={styles.container}>
-      {isRefetching && <LinearProgress sx={styles.progress} />}
+      {isRefetching && !liveSpansState.isOn && (
+        <LinearProgress sx={styles.progress} />
+      )}
       <MaterialReactTable
         columns={columns}
         data={tableSpans}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:

hides the loading indicator when in live mode

## Which issue(s) this PR fixes:

Fixes #1292 

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
