### PR TITLE
fix(trace-graph): fix edge animation unintended removal

### DIFF
--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -131,6 +131,7 @@ export const TraceView = () => {
             >
               <TraceGraph
                 spans={trace}
+                selectedNode={selectedNode}
                 selectedSpanId={selectedSpanId}
                 initiallyFocusedSpanId={initiallyFocusedSpanId}
                 onAutoSelectedNodeChange={handleAutoSelectedNodeChange}


### PR DESCRIPTION
## What this PR does:
Currently, as explained in #1124, there are situations where the dashed line animation on node edges gets removed unexpectedly. This PR fixes this issue.

## Which issue(s) this PR fixes:
Fixes #1124 
Partly fixes #1098, as hovering over a selected node won't unexpectedly unselect the selected node (@itaykat @iozery).