### PR TITLE
feat(e2e tests): Added sqlite connector

### DIFF
--- a/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
+++ b/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const util = require('util');
+import { exec } from "child_process";
+import { Connector } from ".";
+
+const dockerExecCommandPrefix = "docker exec ";
+const sqliteQueryCommandPrefix = "sqlite3 embedded_spans.db ";
+const deleteTableRecordsPrefix = "DELETE FROM "
+const asyncExec = util.promisify(exec);
+
+export class SQLiteConnector extends Connector {
+
+  private containerName: string;
+
+  constructor(containerName: string = "docker-compose-lupa-api-1") {
+    super();
+    this.containerName = containerName;
+  }
+
+  private deleteAllRecords = (): Promise<{}> => {
+    const tables:string[] = [
+      "spans",
+      "scopes",
+      "events",
+      "links",
+      "span_attributes",
+      "scope_attributes",
+      "resource_attributes",
+      "event_attributes",
+      "link_attributes",
+      "span_resource_attributes",
+    ];
+    var cleanPromises:Promise<{}>[] = [];
+    tables.forEach( (table) => {
+      const deleteQuery = "'" + deleteTableRecordsPrefix + table + "'";
+      cleanPromises.push(
+        asyncExec(
+          dockerExecCommandPrefix + 
+          this.containerName + 
+          " " + 
+          sqliteQueryCommandPrefix + 
+          deleteQuery
+      ))
+    });
+    return Promise.all(cleanPromises);
+  };
+
+  private installSqliteCLI = (): Promise<{}> => {
+    return asyncExec(dockerExecCommandPrefix + this.containerName + " apk add --no-cache sqlite")
+  };
+
+  async clean(): Promise<void> {
+    try {
+      await this.installSqliteCLI();
+      await this.deleteAllRecords();
+    } catch (err) {
+      throw new Error(`Connector failed to clean SQLite Spans DB: ${err}`);
+    }
+  }
+}

--- a/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
+++ b/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
@@ -44,7 +44,7 @@ export class SQLiteConnector extends Connector {
       "link_attributes",
       "span_resource_attributes",
     ];
-    var cleanPromises: Promise<{}>[] = [];
+    let cleanPromises: Promise<{}>[] = [];
     tables.forEach((table) => {
       const deleteQuery = "'" + deleteTableRecordsPrefix + table + "'";
       cleanPromises.push(

--- a/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
+++ b/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
@@ -24,7 +24,6 @@ const deleteTableRecordsPrefix = "DELETE FROM ";
 const asyncExec = util.promisify(exec);
 
 export class SQLiteConnector extends Connector {
-
   private containerName: string;
 
   constructor(containerName: string = "docker-compose-lupa-api-1") {
@@ -50,10 +49,10 @@ export class SQLiteConnector extends Connector {
       const deleteQuery = "'" + deleteTableRecordsPrefix + table + "'";
       cleanPromises.push(
         asyncExec(
-          dockerExecCommandPrefix + 
+          dockerExecCommandPrefix +
             this.containerName +
-            " " + 
-            sqliteQueryCommandPrefix + 
+            " " +
+            sqliteQueryCommandPrefix +
             deleteQuery
         )
       );
@@ -63,8 +62,8 @@ export class SQLiteConnector extends Connector {
 
   private installSqliteCLI = (): Promise<{}> => {
     return asyncExec(
-      dockerExecCommandPrefix + 
-        this.containerName + 
+      dockerExecCommandPrefix +
+        this.containerName +
         " apk add --no-cache sqlite"
     );
   };

--- a/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
+++ b/tests/e2e/playwright/utils/connectors/sqlite-connector.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-const util = require('util');
+const util = require("util");
 import { exec } from "child_process";
 import { Connector } from ".";
 
 const dockerExecCommandPrefix = "docker exec ";
 const sqliteQueryCommandPrefix = "sqlite3 embedded_spans.db ";
-const deleteTableRecordsPrefix = "DELETE FROM "
+const deleteTableRecordsPrefix = "DELETE FROM ";
 const asyncExec = util.promisify(exec);
 
 export class SQLiteConnector extends Connector {
@@ -33,7 +33,7 @@ export class SQLiteConnector extends Connector {
   }
 
   private deleteAllRecords = (): Promise<{}> => {
-    const tables:string[] = [
+    const tables: string[] = [
       "spans",
       "scopes",
       "events",
@@ -45,23 +45,28 @@ export class SQLiteConnector extends Connector {
       "link_attributes",
       "span_resource_attributes",
     ];
-    var cleanPromises:Promise<{}>[] = [];
-    tables.forEach( (table) => {
+    var cleanPromises: Promise<{}>[] = [];
+    tables.forEach((table) => {
       const deleteQuery = "'" + deleteTableRecordsPrefix + table + "'";
       cleanPromises.push(
         asyncExec(
           dockerExecCommandPrefix + 
-          this.containerName + 
-          " " + 
-          sqliteQueryCommandPrefix + 
-          deleteQuery
-      ))
+            this.containerName +
+            " " + 
+            sqliteQueryCommandPrefix + 
+            deleteQuery
+        )
+      );
     });
     return Promise.all(cleanPromises);
   };
 
   private installSqliteCLI = (): Promise<{}> => {
-    return asyncExec(dockerExecCommandPrefix + this.containerName + " apk add --no-cache sqlite")
+    return asyncExec(
+      dockerExecCommandPrefix + 
+        this.containerName + 
+        " apk add --no-cache sqlite"
+    );
   };
 
   async clean(): Promise<void> {


### PR DESCRIPTION

## What this PR does:
Added sqlite connector, used to clean all the spans from the SQLite DB. Will be used in the E2E tests flow, when it will be performed on the SQLite spans storage - in #1427
I chose that solution since:
- Just deleting the file can corrupt the DB and can lead to unexpected behavior.
- I preferred not to use the spans DB as a volume (which could remove the need for "docker exec") - that's not the desired behavior when using SQLite as the spans storage DB.

## Which issue(s) this PR fixes:

Fixes #1381 

