### PR TITLE
fix(trace-view): avoid skeleton loader flickering

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
@@ -49,7 +49,8 @@ export const SpanDetailsList = ({
   );
 
   useEffect(() => {
-    setIsLoading(false);
+    const timer = setTimeout(() => setIsLoading(false), 250);
+    return () => clearTimeout(timer);
   }, [sortedSpans, setIsLoading]);
 
   const handleChange = (spanId: string, expanded: boolean) => {


### PR DESCRIPTION
## What this PR does:
Currently, graph nodes that contain a small number (1-3) of spans cause the span list skeleton loader to flicker.
This PR fixes this issue by setting the minimum time to show the skeleton to 250ms.

Before:
https://user-images.githubusercontent.com/37577482/217781043-41ac5a70-0857-4524-9c7a-9af541746ca8.mov

After:
https://user-images.githubusercontent.com/37577482/217781071-e2d18244-6f6c-4f6f-a2e9-9d8317d78002.mov