### PR TITLE
fix: (trace-view) Clicking outside the graph should close the spans panel on the

### DIFF
--- a/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
+++ b/web/src/features/trace/components/SpanDetailsList/SpanDetailsList.tsx
@@ -19,12 +19,11 @@ import { useEffect, useMemo } from "react";
 
 import { InternalSpan } from "@/types/span";
 
-import { GraphNode } from "../TraceGraph/types";
 import { SpanDetails } from "./SpanDetails/SpanDetails";
 import { styles } from "./styles";
 
 interface SpanDetailsListProps {
-  selectedNode: GraphNode | null;
+  spans?: InternalSpan[];
   selectedSpanId: string | null;
   setSelectedSpanId: React.Dispatch<React.SetStateAction<string | null>>;
   isLoading: boolean;
@@ -38,14 +37,12 @@ function sortSpansByStartTime(spans: InternalSpan[]) {
 }
 
 export const SpanDetailsList = ({
-  selectedNode,
+  spans,
   selectedSpanId,
   setSelectedSpanId,
   isLoading,
   setIsLoading,
 }: SpanDetailsListProps) => {
-  const spans = selectedNode ? selectedNode.spans : [];
-
   const sortedSpans = useMemo(
     () => spans && sortSpansByStartTime(spans),
     [spans]
@@ -60,10 +57,6 @@ export const SpanDetailsList = ({
     const nextSelectedSpanId = expanded ? spanId : null;
     setSelectedSpanId(nextSelectedSpanId);
   };
-
-  if (!selectedNode) {
-    return null;
-  }
 
   if (isLoading) {
     return (

--- a/web/src/features/trace/routes/TraceView/TraceView.tsx
+++ b/web/src/features/trace/routes/TraceView/TraceView.tsx
@@ -145,13 +145,15 @@ export const TraceView = () => {
                 onAutoSelectedNodeChange={handleAutoSelectedNodeChange}
                 onGraphNodeClick={handleGraphNodeClick}
               />
-              <SpanDetailsList
-                selectedNode={selectedNode}
-                selectedSpanId={selectedSpanId}
-                setSelectedSpanId={setSelectedSpanId}
-                isLoading={spanDetailsIsLoading}
-                setIsLoading={setSpanDetailsIsLoading}
-              />
+              {selectedNode ? (
+                <SpanDetailsList
+                  spans={selectedNode?.spans}
+                  selectedSpanId={selectedSpanId}
+                  setSelectedSpanId={setSelectedSpanId}
+                  isLoading={spanDetailsIsLoading}
+                  setIsLoading={setSpanDetailsIsLoading}
+                />
+              ) : null}
             </Stack>
           </Stack>
         </ReactSplit>


### PR DESCRIPTION
## What this PR does:
Returned on pane click action and hide spanList if node is not selected
## Which issue(s) this PR fixes:

Fixes #1011 


https://user-images.githubusercontent.com/98012495/218308693-e70ddd56-8bce-46e6-bae6-99dfba61f9ba.mov


