### PR TITLE
refactor: rename oss-tracing module to teletrace

### DIFF
--- a/cmd/all-in-one/main.go
+++ b/cmd/all-in-one/main.go
@@ -22,15 +22,16 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"oss-tracing/pkg/api"
-	"oss-tracing/pkg/config"
-	"oss-tracing/pkg/logs"
-	"oss-tracing/pkg/spanreader"
-	"oss-tracing/pkg/usageReport"
 	"syscall"
 
-	spanreaderes "oss-tracing/plugin/spanreader/es"
-	sqlite "oss-tracing/plugin/spanreader/sqlite"
+	"github.com/teletrace/teletrace/pkg/api"
+	"github.com/teletrace/teletrace/pkg/config"
+	"github.com/teletrace/teletrace/pkg/logs"
+	"github.com/teletrace/teletrace/pkg/spanreader"
+	"github.com/teletrace/teletrace/pkg/usageReport"
+
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es"
+	sqlite "github.com/teletrace/teletrace/plugin/spanreader/sqlite"
 
 	"github.com/epsagon/lupa/lupa-otelcol/pkg/collector"
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -19,11 +19,12 @@ package main
 import (
 	"context"
 	"log"
-	"oss-tracing/pkg/api"
-	"oss-tracing/pkg/config"
-	"oss-tracing/pkg/logs"
-	"oss-tracing/pkg/usageReport"
-	spanreaderes "oss-tracing/plugin/spanreader/es"
+
+	"github.com/teletrace/teletrace/pkg/api"
+	"github.com/teletrace/teletrace/pkg/config"
+	"github.com/teletrace/teletrace/pkg/logs"
+	"github.com/teletrace/teletrace/pkg/usageReport"
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es"
 
 	"go.uber.org/zap"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module oss-tracing
+module github.com/teletrace/teletrace
 
 go 1.19
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,12 +19,13 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"oss-tracing/pkg/config"
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/spanreader"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/config"
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/spanreader"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/static"

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -23,15 +23,16 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"oss-tracing/pkg/config"
-	"oss-tracing/pkg/model"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	spanreader "oss-tracing/pkg/spanreader/mock"
 	"path"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/config"
+	"github.com/teletrace/teletrace/pkg/model"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	spanreader "github.com/teletrace/teletrace/pkg/spanreader/mock"
 
 	spanformatutiltests "github.com/epsagon/lupa/model/internalspan/v1/util"
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -18,11 +18,12 @@ package api
 
 import (
 	"net/http"
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/model/metadata/v1"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 
 	"github.com/gin-gonic/gin"
 )

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -18,7 +18,8 @@ package logs
 
 import (
 	"log"
-	"oss-tracing/pkg/config"
+
+	"github.com/teletrace/teletrace/pkg/config"
 
 	"go.uber.org/zap"
 )

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -17,8 +17,9 @@
 package logs
 
 import (
-	"oss-tracing/pkg/config"
 	"testing"
+
+	"github.com/teletrace/teletrace/pkg/config"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"

--- a/pkg/model/spansquery/v1/spans_query.go
+++ b/pkg/model/spansquery/v1/spans_query.go
@@ -18,7 +18,8 @@ package model
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
+
+	"github.com/teletrace/teletrace/pkg/model"
 
 	internalspan "github.com/epsagon/lupa/model/internalspan/v1"
 )

--- a/pkg/model/tagsquery/v1/tags_query.go
+++ b/pkg/model/tagsquery/v1/tags_query.go
@@ -18,7 +18,8 @@ package tagsquery
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
+
+	"github.com/teletrace/teletrace/pkg/model"
 )
 
 type TagValuesRequest struct {

--- a/pkg/spanreader/interfaces.go
+++ b/pkg/spanreader/interfaces.go
@@ -18,9 +18,10 @@ package spanreader
 
 import (
 	"context"
-	"oss-tracing/pkg/model/metadata/v1"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
+
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 )
 
 type SpanReader interface {

--- a/pkg/spanreader/mock/spanreader.go
+++ b/pkg/spanreader/mock/spanreader.go
@@ -18,13 +18,14 @@ package mock
 
 import (
 	"context"
-	"oss-tracing/pkg/model/metadata/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	"oss-tracing/pkg/spanreader"
+
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	"github.com/teletrace/teletrace/pkg/spanreader"
 
 	internalspan "github.com/epsagon/lupa/model/internalspan/v1"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	spanformatutiltests "github.com/epsagon/lupa/model/internalspan/v1/util"
 )

--- a/pkg/usageReport/useagereporter.go
+++ b/pkg/usageReport/useagereporter.go
@@ -17,7 +17,8 @@ package usageReport
 
 import (
 	"context"
-	"oss-tracing/pkg/model/usageevents"
+
+	"github.com/teletrace/teletrace/pkg/model/usageevents"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"

--- a/pkg/usageReport/util.go
+++ b/pkg/usageReport/util.go
@@ -17,10 +17,11 @@ package usageReport
 
 import (
 	"context"
-	"oss-tracing/pkg/config"
-	"oss-tracing/pkg/model/metadata/v1"
-	"oss-tracing/pkg/spanreader"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/config"
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	"github.com/teletrace/teletrace/pkg/spanreader"
 
 	"github.com/go-co-op/gocron"
 	"go.uber.org/zap"

--- a/plugin/spanreader/es/config.go
+++ b/plugin/spanreader/es/config.go
@@ -18,7 +18,8 @@ package spanreaderes
 
 import (
 	"fmt"
-	"oss-tracing/pkg/config"
+
+	"github.com/teletrace/teletrace/pkg/config"
 )
 
 type ElasticConfig struct {

--- a/plugin/spanreader/es/metadatacontroller/interface.go
+++ b/plugin/spanreader/es/metadatacontroller/interface.go
@@ -18,7 +18,8 @@ package metadatacontroller
 
 import (
 	"context"
-	"oss-tracing/pkg/model/metadata/v1"
+
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 )
 
 type MetadataController interface {

--- a/plugin/spanreader/es/metadatacontroller/metadata_controller.go
+++ b/plugin/spanreader/es/metadatacontroller/metadata_controller.go
@@ -18,8 +18,9 @@ package metadatacontroller
 import (
 	"context"
 	"fmt"
-	"oss-tracing/pkg/model/metadata/v1"
-	"oss-tracing/plugin/spanreader/es/utils"
+
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/utils"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/optype"

--- a/plugin/spanreader/es/searchcontroller/interface.go
+++ b/plugin/spanreader/es/searchcontroller/interface.go
@@ -18,7 +18,8 @@ package searchcontroller
 
 import (
 	"context"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 type SearchController interface {

--- a/plugin/spanreader/es/searchcontroller/parse.go
+++ b/plugin/spanreader/es/searchcontroller/parse.go
@@ -19,7 +19,8 @@ package searchcontroller
 import (
 	"encoding/json"
 	"fmt"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	internalspan "github.com/epsagon/lupa/model/internalspan/v1"
 	"github.com/mitchellh/mapstructure"

--- a/plugin/spanreader/es/searchcontroller/search_controller.go
+++ b/plugin/spanreader/es/searchcontroller/search_controller.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"oss-tracing/plugin/spanreader/es/errors"
-	spanreaderes "oss-tracing/plugin/spanreader/es/utils"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/errors"
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es/utils"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"

--- a/plugin/spanreader/es/searchcontroller/search_controller_test.go
+++ b/plugin/spanreader/es/searchcontroller/search_controller_test.go
@@ -18,10 +18,11 @@ package searchcontroller
 
 import (
 	"encoding/json"
-	"oss-tracing/pkg/model"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
 	"testing"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/model"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/plugin/spanreader/es/span_reader.go
+++ b/plugin/spanreader/es/span_reader.go
@@ -19,15 +19,16 @@ package spanreaderes
 import (
 	"context"
 	"fmt"
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/model/metadata/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	"oss-tracing/pkg/spanreader"
-	"oss-tracing/plugin/spanreader/es/metadatacontroller"
-	"oss-tracing/plugin/spanreader/es/searchcontroller"
-	"oss-tracing/plugin/spanreader/es/tagscontroller"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	"github.com/teletrace/teletrace/pkg/spanreader"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/metadatacontroller"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/searchcontroller"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/tagscontroller"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	"go.uber.org/zap"
 )

--- a/plugin/spanreader/es/tagscontroller/errors.go
+++ b/plugin/spanreader/es/tagscontroller/errors.go
@@ -19,7 +19,8 @@ package tagscontroller
 import (
 	"encoding/json"
 	"fmt"
-	"oss-tracing/plugin/spanreader/es/errors"
+
+	"github.com/teletrace/teletrace/plugin/spanreader/es/errors"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
 )

--- a/plugin/spanreader/es/tagscontroller/interface.go
+++ b/plugin/spanreader/es/tagscontroller/interface.go
@@ -18,7 +18,8 @@ package tagscontroller
 
 import (
 	"context"
-	"oss-tracing/pkg/model/tagsquery/v1"
+
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 )
 
 type TagsController interface {

--- a/plugin/spanreader/es/tagscontroller/statistics/handler.go
+++ b/plugin/spanreader/es/tagscontroller/statistics/handler.go
@@ -17,7 +17,7 @@
 package statistics
 
 import (
-	"oss-tracing/pkg/model/tagsquery/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 )

--- a/plugin/spanreader/es/tagscontroller/statistics/option.go
+++ b/plugin/spanreader/es/tagscontroller/statistics/option.go
@@ -17,9 +17,9 @@
 package statistics
 
 import (
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	spanreaderes "oss-tracing/plugin/spanreader/es/utils"
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es/utils"
 )
 
 type TagStatisticParseOption func(string, map[tagsquery.TagStatistic]float64, tagsquery.TagStatistic)

--- a/plugin/spanreader/es/tagscontroller/tags_controller.go
+++ b/plugin/spanreader/es/tagscontroller/tags_controller.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	"oss-tracing/plugin/spanreader/es/errors"
-	"oss-tracing/plugin/spanreader/es/tagscontroller/statistics"
 	"strings"
 
-	spanreaderes "oss-tracing/plugin/spanreader/es/utils"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/errors"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/tagscontroller/statistics"
+
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es/utils"
 
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"

--- a/plugin/spanreader/es/tagscontroller/tags_controller_test.go
+++ b/plugin/spanreader/es/tagscontroller/tags_controller_test.go
@@ -20,9 +20,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/model/tagsquery/v1"
 	"testing"
+
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/plugin/spanreader/es/utils/common.go
+++ b/plugin/spanreader/es/utils/common.go
@@ -20,9 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"oss-tracing/pkg/model"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
-	"oss-tracing/plugin/spanreader/es/errors"
+
+	"github.com/teletrace/teletrace/pkg/model"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/errors"
 
 	"golang.org/x/exp/slices"
 

--- a/plugin/spanreader/es/utils/filter_factory.go
+++ b/plugin/spanreader/es/utils/filter_factory.go
@@ -19,9 +19,10 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"oss-tracing/pkg/model"
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
 	"strconv"
+
+	"github.com/teletrace/teletrace/pkg/model"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 )

--- a/plugin/spanreader/es/utils/filter_factory_test.go
+++ b/plugin/spanreader/es/utils/filter_factory_test.go
@@ -18,8 +18,9 @@ package utils
 
 import (
 	"encoding/json"
-	"oss-tracing/pkg/model"
 	"testing"
+
+	"github.com/teletrace/teletrace/pkg/model"
 
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/stretchr/testify/assert"

--- a/plugin/spanreader/sqlite/config.go
+++ b/plugin/spanreader/sqlite/config.go
@@ -16,7 +16,7 @@
 
 package sqlitespanreader
 
-import "oss-tracing/pkg/config"
+import "github.com/teletrace/teletrace/pkg/config"
 
 type SqliteConfig struct {
 	Path string

--- a/plugin/spanreader/sqlite/filters_utils.go
+++ b/plugin/spanreader/sqlite/filters_utils.go
@@ -18,10 +18,11 @@ package sqlitespanreader
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
 	"strings"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 var sqliteFieldsMap = map[string]string{

--- a/plugin/spanreader/sqlite/filters_utils_test.go
+++ b/plugin/spanreader/sqlite/filters_utils_test.go
@@ -18,8 +18,9 @@ package sqlitespanreader
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
 	"testing"
+
+	"github.com/teletrace/teletrace/pkg/model"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/plugin/spanreader/sqlite/order_builder.go
+++ b/plugin/spanreader/sqlite/order_builder.go
@@ -18,9 +18,10 @@ package sqlitespanreader
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 type extractOrderResponse struct {

--- a/plugin/spanreader/sqlite/query_factory.go
+++ b/plugin/spanreader/sqlite/query_factory.go
@@ -18,11 +18,12 @@ package sqlitespanreader
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
-	"oss-tracing/pkg/model/tagsquery/v1"
 	"strings"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 const (

--- a/plugin/spanreader/sqlite/sort_utils.go
+++ b/plugin/spanreader/sqlite/sort_utils.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 type sqliteOrder struct {

--- a/plugin/spanreader/sqlite/span_reader.go
+++ b/plugin/spanreader/sqlite/span_reader.go
@@ -19,15 +19,16 @@ package sqlitespanreader
 import (
 	"context"
 	"fmt"
-	"oss-tracing/pkg/model/metadata/v1"
-	"oss-tracing/pkg/model/tagsquery/v1"
-	"oss-tracing/pkg/spanreader"
+
+	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
+	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	"github.com/teletrace/teletrace/pkg/spanreader"
 
 	internalspan "github.com/epsagon/lupa/model/internalspan/v1"
 
 	"go.uber.org/zap"
 
-	spansquery "oss-tracing/pkg/model/spansquery/v1"
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 )
 
 type spanReader struct {

--- a/plugin/spanreader/sqlite/sub_query_builder.go
+++ b/plugin/spanreader/sqlite/sub_query_builder.go
@@ -18,8 +18,9 @@ package sqlitespanreader
 
 import (
 	"fmt"
-	"oss-tracing/pkg/model"
 	"strings"
+
+	"github.com/teletrace/teletrace/pkg/model"
 )
 
 type subQueryBuilder struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Renames the oss-tracing module to teletrace.
This is only the first part of the renaming process, other PRs will follow.