### PR TITLE
docs: add missing dependency

### DIFF
--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-awesome-pages-plugin
+mkdocs-material


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Add `mkdocs-material` as a dependency to docs requirements.