### PR TITLE
refactor: update slack workspace link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <h3 align="center">
   <a href="https://docs.lupaproject.io/"><b>📝 Explore the docs</b></a> &bull;
-  <a href="https://join.slack.com/t/lupa-space/shared_invite/zt-1kyuehmaq-Dbut6qMpKak~SHx1DmZTEQ"><b>💬 Join Our Slack</b></a> &bull;
+  <a href="https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ"><b>💬 Join Our Slack</b></a> &bull;
   <a href="https://github.com/epsagon/lupa/issues/new?assignees=&labels=&template=bug_report.md&title="><b>🐛 Report Bug</b></a> &bull;
   <a href="https://github.com/epsagon/lupa/issues/new?assignees=&labels=&template=feature_request.md&title="><b>✨ Request Feature</b></a>
 </h3>
@@ -113,7 +113,7 @@ Start by reviewing the [contribution guidelines](CONTRIBUTING.md). After that, t
 
 ## 💬 **Community**
 
-Join our [Slack](https://join.slack.com/t/lupa-space/shared_invite/zt-1kyuehmaq-Dbut6qMpKak~SHx1DmZTEQ) for questions, support and fun.
+Join our [Slack](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ) for questions, support and fun.
 
 Start with our [Documentation](https://docs.lupaproject.io/) for quick tutorials and examples.
 

--- a/web/src/config/index.ts
+++ b/web/src/config/index.ts
@@ -21,7 +21,7 @@ export const API_URL = process.env.REACT_APP_API_URL ?? LOCAL_API_URL;
 export const TELETRACE_DOCS_URL = "https://docs.lupaproject.io/";
 export const TELETRACE_REPOSITORY_URL = "https://github.com/epsagon/lupa";
 export const TELETRACE_SLACK_INVITE_LINK =
-  "https://join.slack.com/t/lupa-space/shared_invite/zt-1kyuehmaq-Dbut6qMpKak~SHx1DmZTEQ";
+  "https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ";
 
 export const TELETRACE_BUILD_INFO =
   process.env.REACT_APP_BUILD_INFO ?? "v0.0.0-devel";

--- a/website/docs/contribution.md
+++ b/website/docs/contribution.md
@@ -5,5 +5,5 @@ We are happy to receive contributions in all forms, as well as feedback and new 
 - Suggest an improvement and new ideas in a GitHub [discussion](https://github.com/epsagon/lupa/discussions/new).
 - Create a new [issue](https://github.com/epsagon/lupa/issues/new/choose) to report a bug or request a feature.
 - Fix a bug yourself or implement new functionality by exploring the [issues tracker](https://github.com/epsagon/lupa/issues) and choosing an issue.
-- Join our [Slack](https://join.slack.com/t/lupa-space/shared_invite/zt-1kyuehmaq-Dbut6qMpKak~SHx1DmZTEQ) workspace to discuss ideas and collaborate with other contributors.
+- Join our [Slack](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ) workspace to discuss ideas and collaborate with other contributors.
 - Contribution guide can be found [here](https://github.com/epsagon/lupa/blob/main/CONTRIBUTING.md)

--- a/website/docs/support.md
+++ b/website/docs/support.md
@@ -2,6 +2,6 @@
 
 1. Make sure you've read [understanding the basics](understand_the_basics.md) and [getting started guide](getting_started.md).
 2. Looked for an answer in [the frequently asked questions](faq.md).
-3. Ask a question in [Teletrace Slack channel ⧉](https://join.slack.com/t/lupa-space/shared_invite/zt-1kyuehmaq-Dbut6qMpKak~SHx1DmZTEQ).
+3. Ask a question in [Teletrace Slack channel ⧉](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ).
 4. [Read issues, report a bug, or request a feature ⧉](https://github.com/epsagon/lupa/issues).
 5. You always can reach us and ask for help by sending us an email: **teletrace@cisco.com**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Update the Slack workspace invite link from the Lupa workspace to Teletrace.