### PR TITLE
fix(docs): update examples image tag version

### DIFF
--- a/website/docs/getting_started.md
+++ b/website/docs/getting_started.md
@@ -23,7 +23,7 @@ services:
       - ./teletrace-collector-config.yaml:/etc/teletrace-collector-config.yaml
     environment:
       - ES_ENDPOINT=http://elasticsearch:9200
-    image: teletrace/teletrace:v0.5
+    image: teletrace/teletrace:v0.6
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "localhost:8080/v1/ping"]
       interval: 60s

--- a/website/docs/user-guide/deployment/docker_compose.md
+++ b/website/docs/user-guide/deployment/docker_compose.md
@@ -23,7 +23,7 @@ services:
       - ./teletrace-collector-config.yaml:/etc/teletrace-collector-config.yaml
     environment:
       - ES_ENDPOINT=http://elasticsearch:9200
-    image: teletrace/teletrace:v0.5
+    image: teletrace/teletrace:v0.6
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "localhost:8080/v1/ping"]
       interval: 60s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Updates the teletrace image tag version in docs examples (currently broken, as v0.6.0 is the first teletrace version).