### PR TITLE
fix(docs): update lupa links to teletrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 <h1 align="center">The Open-Source Tracing Platform.</h1>
 
 <h3 align="center">
-  <a href="https://docs.lupaproject.io/"><b>📝 Explore the docs</b></a> &bull;
+  <a href="https://docs.teletrace.io/"><b>📝 Explore the docs</b></a> &bull;
   <a href="https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ"><b>💬 Join Our Slack</b></a> &bull;
-  <a href="https://github.com/epsagon/lupa/issues/new?assignees=&labels=&template=bug_report.md&title="><b>🐛 Report Bug</b></a> &bull;
-  <a href="https://github.com/epsagon/lupa/issues/new?assignees=&labels=&template=feature_request.md&title="><b>✨ Request Feature</b></a>
+  <a href="https://github.com/teletrace/teletrace/issues/new?assignees=&labels=&template=bug_report.md&title="><b>🐛 Report Bug</b></a> &bull;
+  <a href="https://github.com/teletrace/teletrace/issues/new?assignees=&labels=&template=feature_request.md&title="><b>✨ Request Feature</b></a>
 </h3>
 
 ## ⭐️ **Why Teletrace?**

--- a/website/docs/contribution.md
+++ b/website/docs/contribution.md
@@ -2,8 +2,8 @@
 
 We are happy to receive contributions in all forms, as well as feedback and new ideas.
 
-- Suggest an improvement and new ideas in a GitHub [discussion](https://github.com/epsagon/lupa/discussions/new).
-- Create a new [issue](https://github.com/epsagon/lupa/issues/new/choose) to report a bug or request a feature.
-- Fix a bug yourself or implement new functionality by exploring the [issues tracker](https://github.com/epsagon/lupa/issues) and choosing an issue.
+- Suggest an improvement and new ideas in a GitHub [discussion](https://github.com/teletrace/teletrace/discussions/new/choose).
+- Create a new [issue](https://github.com/teletrace/teletrace/issues/new/choose) to report a bug or request a feature.
+- Fix a bug yourself or implement new functionality by exploring the [issues tracker](https://github.com/teletrace/teletrace/issues) and choosing an issue.
 - Join our [Slack](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ) workspace to discuss ideas and collaborate with other contributors.
-- Contribution guide can be found [here](https://github.com/epsagon/lupa/blob/main/CONTRIBUTING.md)
+- Contribution guide can be found [here](https://github.com/teletrace/teletrace/blob/main/CONTRIBUTING.md)

--- a/website/docs/support.md
+++ b/website/docs/support.md
@@ -3,5 +3,5 @@
 1. Make sure you've read [understanding the basics](understand_the_basics.md) and [getting started guide](getting_started.md).
 2. Looked for an answer in [the frequently asked questions](faq.md).
 3. Ask a question in [Teletrace Slack channel ⧉](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ).
-4. [Read issues, report a bug, or request a feature ⧉](https://github.com/epsagon/lupa/issues).
+4. [Read issues, report a bug, or request a feature ⧉](https://github.com/teletrace/teletrace/issues).
 5. You always can reach us and ask for help by sending us an email: **teletrace@cisco.com**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
Updates older lupa links to newer teletrace links.
