### PR TITLE
fix: fixed .keyword suffix appearing in add filter when ES is backend

### DIFF
--- a/plugin/spanreader/es/tagscontroller/tags_controller.go
+++ b/plugin/spanreader/es/tagscontroller/tags_controller.go
@@ -378,12 +378,12 @@ func removeDuplicatedTextTags(tags []tagsquery.TagInfo) []tagsquery.TagInfo {
 	}
 
 	for _, tag := range tags {
-		if tag.Type == "keyword" {
-			if strings.Contains(tag.Name, ".keyword") {
+		if tag.Type == pcommon.ValueTypeStr.String() {
+			if strings.HasSuffix(tag.Name, ".keyword") {
 				strippedName := tag.Name[:len(tag.Name)-len(".keyword")]
 				// If there exists a duplication for the same tag, as text and as keyword
 				// This happens then the index is using the default elasticsearch mapping.
-				if !(slices.Contains(tagsNames, strippedName) && (tagsNamesToTypes[strippedName] == "text")) {
+				if !(slices.Contains(tagsNames, strippedName) && (tagsNamesToTypes[strippedName] == pcommon.ValueTypeStr.String())) {
 					validTags = append(validTags, tag)
 				}
 			} else {

--- a/plugin/spanreader/es/tagscontroller/tags_controller_test.go
+++ b/plugin/spanreader/es/tagscontroller/tags_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/teletrace/teletrace/pkg/model"
 	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -175,15 +176,15 @@ func Test_RemoveDuplicatedTextTags_RemoveTextDuplicates(t *testing.T) {
 	tagsMock := []tagsquery.TagInfo{
 		{
 			Name: "span.attributes.http.method.keyword",
-			Type: "keyword",
+			Type: pcommon.ValueTypeStr.String(),
 		},
 		{
 			Name: "span.attributes.http.method",
-			Type: "text",
+			Type: pcommon.ValueTypeStr.String(),
 		},
 		{
 			Name: "span.attributes.http.method.not_keyword",
-			Type: "keyword",
+			Type: pcommon.ValueTypeStr.String(),
 		},
 	}
 

--- a/web/src/features/search/components/EmptyState/index.tsx
+++ b/web/src/features/search/components/EmptyState/index.tsx
@@ -132,7 +132,7 @@ export const EmptyState = () => {
           backgroundColor: "rgba(84, 140, 255, 0.12)",
         }}
       >
-        Once you will finish, please refresh the page to see your spans
+        Once you finish, please refresh the page to see your spans
       </Alert>
     </Stack>
   );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does: fixes the function that removes .keyword suffixed text tags in ES plugin

## Which issue(s) this PR fixes: #1559 

Fixes #<issue number>

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
