### PR TITLE
fix: editing a filter to an existing key+operator combination will override the previous filter

### DIFF
--- a/web/src/features/search/stores/spanSearchStore.ts
+++ b/web/src/features/search/stores/spanSearchStore.ts
@@ -143,6 +143,20 @@ const createFiltersSlice: StateCreator<
       previousFilter?: SearchFilter
     ) =>
       set((state) => {
+        const handlePreExisitingFilterOverride = () => {
+          const filterIndex = state.filtersState.filters.findIndex((f) =>
+            isFiltersStructureEqual(
+              f.keyValueFilter.key,
+              filter.keyValueFilter.key,
+              f.keyValueFilter.operator,
+              filter.keyValueFilter.operator
+            )
+          );
+          if (filterIndex !== -1) {
+            state.filtersState.filters.splice(filterIndex, 1);
+          }
+        };
+
         const targetFilter = previousFilter ?? filter;
         const filterToUpdate = state.filtersState.filters.find((f) =>
           isFiltersStructureEqual(
@@ -154,6 +168,9 @@ const createFiltersSlice: StateCreator<
         );
 
         if (filterToUpdate !== undefined) {
+          if (previousFilter) {
+            handlePreExisitingFilterOverride();
+          }
           filterToUpdate.keyValueFilter = filter.keyValueFilter;
         } else {
           state.filtersState.filters.push(filter);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does


https://user-images.githubusercontent.com/40536014/229856905-290aa6eb-bcd1-4fda-9de2-e55986c014c4.mov




## Which issue(s) this PR fixes:

Fixes #1266 


## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
