### PR TITLE
refactor: update helm charts repo references after rename

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -16,7 +16,7 @@ Overall, using OpenTelemetry with Teletrace can provide a powerful observability
 
 ## What are deployment types available for Teletrace?
 
-Teletrace can be deployed using [Helm](https://helm.sh/) which is a popular package manager for Kubernetes. The Teletrace [Helm chart](https://github.com/teletrace/teletrace-helm-charts) provides a set of preconfigured templates for deploying Teletrace. Using Helm can simplify the deployment process and make it easier to manage and scale Teletrace.
+Teletrace can be deployed using [Helm](https://helm.sh/) which is a popular package manager for Kubernetes. The Teletrace [Helm chart](https://github.com/teletrace/helm-charts) provides a set of preconfigured templates for deploying Teletrace. Using Helm can simplify the deployment process and make it easier to manage and scale Teletrace.
 In addition, Teletrace can be deployed using [Docker Compose](https://docs.docker.com/compose/), which is a tool for defining and running multi-container Docker applications. The Teletrace Docker Compose file provides a set of preconfigured services for deploying Teletrace, including the Teletrace API, and storage backend. Using Docker Compose can simplify the deployment process and make it easier to test and develop Teletrace locally.
 
 ## How and where does Teletrace store data?

--- a/website/docs/user-guide/deployment/helm_chart.md
+++ b/website/docs/user-guide/deployment/helm_chart.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This tutorial will guide you through the process of installing Teletrace, an open-source tracing system, using Helm chart. [Helm](https://helm.sh/) is a package manager for Kubernetes that makes it easy to install, upgrade, and manage applications in Kubernetes. The Teletrace Helm chart is available on the [official repository](https://github.com/teletrace/teletrace-helm-charts) and makes it easy to install and configure Teletrace in a Kubernetes cluster.
+This tutorial will guide you through the process of installing Teletrace, an open-source tracing system, using Helm chart. [Helm](https://helm.sh/) is a package manager for Kubernetes that makes it easy to install, upgrade, and manage applications in Kubernetes. The Teletrace Helm chart is available on the [official repository](https://github.com/teletrace/helm-charts) and makes it easy to install and configure Teletrace in a Kubernetes cluster.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ This tutorial will guide you through the process of installing Teletrace, an ope
 
 1. Add the Teletrace Helm repository to your local Helm installation:
 ```sh
-helm repo add teletrace https://teletrace.github.io/teletrace-helm-charts/
+helm repo add teletrace https://teletrace.github.io/helm-charts/
 ```
 
 2. Update the Helm repository to ensure that you have the latest version of the Teletrace Helm chart:


### PR DESCRIPTION
Updates all the teletrace helm charts repository references to the new repository name that was introduced in: https://github.com/teletrace/helm-charts/pull/25