### PR TITLE
fix: remove dynamic branch badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Slack](https://img.shields.io/badge/slack-teletrace-brightgreen.svg?logo=slack)](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ)
 [![Version](https://img.shields.io/github/v/release/teletrace/teletrace?color=blueviolet)](https://github.com/teletrace/teletrace/releases)
 [![Commits](https://img.shields.io/github/commits-since/teletrace/teletrace/latest?color=ff69b4&include_prereleases)](https://github.com/teletrace/teletrace/graphs/commit-activity)
-[![Build Status](https://github.com/teletrace/teletrace/actions/workflows/run-end-to-end-tests.yml/badge.svg)](https://github.com/teletrace/teletrace/actions/workflows/run-end-to-end-tests.yml)
 [![Merge Queue](https://github.com/teletrace/teletrace/actions/workflows/merge-queue.yml/badge.svg)](https://github.com/teletrace/teletrace/actions/workflows/merge-queue.yml)
 [![Docs](https://github.com/teletrace/teletrace/actions/workflows/docs.yml/badge.svg)](https://docs.teletrace.io/)
 [![Go Report](https://img.shields.io/badge/go%20report-A+-brightgreen.svg?color=blue)](https://goreportcard.com/report/github.com/teletrace/teletrace)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Slack](https://img.shields.io/badge/slack-teletrace-brightgreen.svg?logo=slack)](https://join.slack.com/t/teletrace/shared_invite/zt-1qv0kogcn-KlbBB2yS~gUCGszZoSpJfQ)
 [![Version](https://img.shields.io/github/v/release/teletrace/teletrace?color=blueviolet)](https://github.com/teletrace/teletrace/releases)
 [![Commits](https://img.shields.io/github/commits-since/teletrace/teletrace/latest?color=ff69b4&include_prereleases)](https://github.com/teletrace/teletrace/graphs/commit-activity)
-[![Merge Queue](https://github.com/teletrace/teletrace/actions/workflows/merge-queue.yml/badge.svg)](https://github.com/teletrace/teletrace/actions/workflows/merge-queue.yml)
+[![Merge Queue](https://img.shields.io/endpoint.svg?url=https://api.mergify.com/v1/badges/teletrace/teletrace&style=flat)](https://github.com/teletrace/teletrace/actions/workflows/merge-queue.yml)
 [![Docs](https://github.com/teletrace/teletrace/actions/workflows/docs.yml/badge.svg)](https://docs.teletrace.io/)
 [![Go Report](https://img.shields.io/badge/go%20report-A+-brightgreen.svg?color=blue)](https://goreportcard.com/report/github.com/teletrace/teletrace)
 [![Contributors](https://img.shields.io/github/contributors/teletrace/teletrace.svg?color=orange)](https://github.com/teletrace/teletrace/graphs/contributors)


### PR DESCRIPTION
**Issue:**
The e2e tests action badge shows an incorrect status (failed instead of success).

**Reason:**
This is because a Github action badge must point to a specific branch (default one if no query param is supplied).
In our case, the e2e tests are running on a dynamic branch name created by Mergify on each PR, which can't be referred to in the badge URL.

**Solution:**
It is not that important. Let's remove it for now instead of showing an incorrect result.
Also, the merge-queue badge suffers from the same issue (shows success because it probably refers to some tests we've done on the main branch in the past). So I've also changed it to the [Mergify badge](https://docs.mergify.com/badge/).