### PR TITLE
fix(ui): remove empty trace diagram dom elements

### DIFF
--- a/web/src/features/trace/components/TraceGraph/BasicEdge/BasicEdge.tsx
+++ b/web/src/features/trace/components/TraceGraph/BasicEdge/BasicEdge.tsx
@@ -51,16 +51,15 @@ const BasicEdgeImpl = ({
         d={edgePath}
         markerEnd={markerEnd}
       />
-      <foreignObject
-        width={FOREIGN_OBJECT_WIDTH}
-        height={FOREIGN_OBJECT_HEIGHT}
-        x={labelX - FOREIGN_OBJECT_WIDTH / 2}
-        y={labelY - FOREIGN_OBJECT_HEIGHT / 2}
-        requiredExtensions="http://www.w3.org/1999/xhtml"
-      >
-        <Box sx={styles.edgeLabelContainer}>
-          <Box sx={styles.timeContainer}>{data.time}</Box>
-          {data?.count && (
+      {data?.count && (
+        <foreignObject
+          width={FOREIGN_OBJECT_WIDTH}
+          height={FOREIGN_OBJECT_HEIGHT}
+          x={labelX - FOREIGN_OBJECT_WIDTH / 2}
+          y={labelY - FOREIGN_OBJECT_HEIGHT / 2}
+          requiredExtensions="http://www.w3.org/1999/xhtml"
+        >
+          <Box sx={styles.edgeLabelContainer}>
             <Box
               sx={{
                 ...styles.counterContainer,
@@ -69,9 +68,9 @@ const BasicEdgeImpl = ({
             >
               {data.count}
             </Box>
-          )}
-        </Box>
-      </foreignObject>
+          </Box>
+        </foreignObject>
+      )}
     </>
   );
 };

--- a/web/src/features/trace/components/TraceGraph/BasicEdge/styles.ts
+++ b/web/src/features/trace/components/TraceGraph/BasicEdge/styles.ts
@@ -29,10 +29,6 @@ export const styles = {
       cursor: "default",
     },
   },
-  timeContainer: {
-    color: "#ffffff",
-    background: "#0B0B0D",
-  },
   counterContainer: {
     background: "#3b3c42",
     border: 1,


### PR DESCRIPTION
In https://github.com/teletrace/teletrace/pull/1443 the duration container was removed for the diagram edges. 
The duration container wasn't removed completely, which caused an empty element to be rendered for each edge.