### PR TITLE
docs: fix incorrect demo repo link

### DIFF
--- a/website/docs/user-guide/open_telemetry_demo.md
+++ b/website/docs/user-guide/open_telemetry_demo.md
@@ -25,7 +25,7 @@ Before using the Teletrace OpenTelemetry Demo, ensure that you have the followin
 Follow the steps below to get started with the Teletrace OpenTelemetry Demo:
 1. Clone the Teletrace OpenTelemetry Demo repository:
 ```sh
-git clone https://github.com/opentelemetry/opentelemetry-demo.git
+git clone https://github.com/teletrace/opentelemetry-demo.git
 ```
 
 2. Navigate to opentelemetry demo folder


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

## What this PR does:
The current instructions for running the Teletrace demo are incorrect because of an incorrect demo repository link. This PR fixes the issue by pointing to the correct repository.

## Which issue(s) this PR fixes:
Fixes #1594 
