### PR TITLE
feat: Histograms API & Elasticsearch Implementation

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -114,6 +114,7 @@ func (api *API) registerRoutes() {
 	v1.GET("/tags", api.getAvailableTags)
 	v1.POST("/tags/:tag", api.tagsValues)
 	v1.POST("/tags/:tag/statistics", api.tagsStatistics)
+	v1.POST("/histogram", api.histogram)
 }
 
 // Start runs the configured API instance.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -135,5 +135,6 @@ func (api *API) validateRequestBody(req model.Request, c *gin.Context) bool {
 		respondWithError(http.StatusBadRequest, validationError, c)
 		return true
 	}
+
 	return false
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -114,7 +114,7 @@ func (api *API) registerRoutes() {
 	v1.GET("/tags", api.getAvailableTags)
 	v1.POST("/tags/:tag", api.tagsValues)
 	v1.POST("/tags/:tag/statistics", api.tagsStatistics)
-	v1.POST("/histogram", api.histogram)
+	v1.POST("/histograms", api.histograms)
 }
 
 // Start runs the configured API instance.

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,6 +27,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/config"
 	"github.com/teletrace/teletrace/pkg/model"
@@ -313,8 +314,8 @@ func TestHistograms(t *testing.T) {
 
 	expectedBuckets := 3
 	expectedFirstSubBucketsLength := 2
-	var expectedFirstSubBucketCount = float64(76)
-	var expectedFirstSubBucketKey = float64(500)
+	expectedFirstSubBucketCount := float64(76)
+	expectedFirstSubBucketKey := float64(500)
 	expectedThirdSubBucketsLength := 0
 	var resBody *aggsquery.HistogramsResponse
 	err := json.NewDecoder(resRecorder.Body).Decode(&resBody)

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -17,9 +17,12 @@
 package api
 
 import (
-	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"net/http"
 	"time"
+
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/model"
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -129,15 +129,15 @@ func (api *API) tagsStatistics(c *gin.Context) {
 	c.JSON(http.StatusOK, res)
 }
 
-func (api *API) histogram(c *gin.Context) {
-	var req aggsquery.HistogramRequest
+func (api *API) histograms(c *gin.Context) {
+	var req aggsquery.HistogramsRequest
 	isValidationError := api.validateRequestBody(&req, c)
 	if isValidationError {
 		return
 	}
 	handleTimeframe(req.Timeframe)
 
-	res, err := (*api.spanReader).GetHistogram(c, req)
+	res, err := (*api.spanReader).GetHistograms(c, req)
 	if err != nil {
 		respondWithError(http.StatusInternalServerError, err, c)
 		return

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"net/http"
 	"time"
 
@@ -120,6 +121,23 @@ func (api *API) tagsStatistics(c *gin.Context) {
 	tag := c.Param("tag")
 
 	res, err := (*api.spanReader).GetTagsStatistics(c, req, tag)
+	if err != nil {
+		respondWithError(http.StatusInternalServerError, err, c)
+		return
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+func (api *API) histogram(c *gin.Context) {
+	var req aggsquery.HistogramRequest
+	isValidationError := api.validateRequestBody(&req, c)
+	if isValidationError {
+		return
+	}
+	handleTimeframe(req.Timeframe)
+
+	res, err := (*api.spanReader).GetHistogram(c, req)
 	if err != nil {
 		respondWithError(http.StatusInternalServerError, err, c)
 		return

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
-	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
-
 	"github.com/teletrace/teletrace/pkg/model"
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -1,0 +1,40 @@
+package aggsquery
+
+import "github.com/teletrace/teletrace/pkg/model"
+
+type HistogramRequest struct {
+	Timeframe     *model.Timeframe       `json:"timeframe"`
+	SearchFilters []model.SearchFilter   `json:"filters"`
+	Interval      float64                `json:"interval"`
+	IntervalKey   string                 `json:"intervalKey"`
+	Aggregations  map[string]Aggregation `json:"aggregations"`
+}
+
+type AggregationFunction string
+
+const (
+	COUNT          AggregationFunction = "COUNT"
+	DISTINCT_COUNT AggregationFunction = "DISTINCT_COUNT"
+	PERCENTILES    AggregationFunction = "PERCENTILES"
+)
+
+type Aggregation struct {
+	Func      AggregationFunction `json:"func"`
+	GroupBy   string              `json:"groupBy,omitempty"`
+	MaxGroups int                 `json:"maxGroups,omitempty"`
+	Key       string              `json:"key,omitempty"`
+}
+
+type HistogramResponse struct {
+	Histograms []Histogram `json:"histograms"`
+}
+
+type Bucket struct {
+	BucketKey any `json:"bucketKey"`
+	Data      any `json:"data"`
+}
+
+type Histogram struct {
+	HistogramLabel string   `json:"histogramLabel"`
+	Buckets        []Bucket `json:"buckets"`
+}

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -21,7 +21,7 @@ import (
 	"github.com/teletrace/teletrace/pkg/model"
 )
 
-type HistogramRequest struct {
+type HistogramsRequest struct {
 	Timeframe     *model.Timeframe       `json:"timeframe"`
 	SearchFilters []model.SearchFilter   `json:"filters"`
 	Interval      float64                `json:"interval"`
@@ -44,7 +44,7 @@ type Aggregation struct {
 	Key       string              `json:"key,omitempty"`
 }
 
-type HistogramResponse struct {
+type HistogramsResponse struct {
 	Histograms []Histogram `json:"histograms"`
 }
 
@@ -58,7 +58,7 @@ type Histogram struct {
 	Buckets        []Bucket `json:"buckets"`
 }
 
-func (sr *HistogramRequest) Validate() error {
+func (sr *HistogramsRequest) Validate() error {
 	if (sr.Timeframe.EndTime < sr.Timeframe.StartTime) && (sr.Timeframe.EndTime != 0) {
 		return fmt.Errorf("endTime cannot be smaller than startTime")
 	}

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -22,6 +22,12 @@ import (
 	"github.com/teletrace/teletrace/pkg/model"
 )
 
+const (
+	SpanIdKey       = "span.spanId.keyword"
+	SubBucketsField = "subBuckets"
+	TotalCountField = "totalCount"
+)
+
 type HistogramsRequest struct {
 	Timeframe     *model.Timeframe       `json:"timeframe"`
 	SearchFilters []model.SearchFilter   `json:"filters"`
@@ -66,6 +72,8 @@ type Bucket struct {
 	BucketKey any `json:"bucketKey"`
 	Data      any `json:"data"`
 }
+
+type SubBucketsData map[string]any
 
 type Histogram struct {
 	HistogramLabel string   `json:"histogramLabel"`

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -51,11 +51,11 @@ const (
 )
 
 type Aggregation struct {
-	Func                  AggregationFunction          `json:"func"`
-	GroupBy               string                       `json:"groupBy,omitempty"`
-	MaxGroups             int                          `json:"maxGroups,omitempty"`
-	Key                   string                       `json:"key,omitempty"`
-	AggregationParameters map[AggregationParameter]any `json:"aggregationParameters,omitempty"`
+	Func              AggregationFunction          `json:"func"`
+	GroupBy           string                       `json:"groupBy,omitempty"`
+	MaxGroups         int                          `json:"maxGroups,omitempty"`
+	Key               string                       `json:"key,omitempty"`
+	AggFunctionParams map[AggregationParameter]any `json:"aggregationParameters,omitempty"`
 }
 
 var AggregationFuncToSupportedParameters = map[AggregationFunction][]AggregationParameter{
@@ -73,8 +73,6 @@ type Bucket struct {
 	Data      any `json:"data"`
 }
 
-type SubBucketsData map[string]any
-
 type Histogram struct {
 	HistogramLabel string   `json:"histogramLabel"`
 	Buckets        []Bucket `json:"buckets"`
@@ -88,7 +86,7 @@ func (sr *HistogramsRequest) Validate() error {
 	// Search for aggregation parameters
 	for _, agg := range sr.Aggregations {
 		for _, p := range AggregationFuncToSupportedParameters[agg.Func] {
-			_, ok := agg.AggregationParameters[p]
+			_, ok := agg.AggFunctionParams[p]
 			if !ok {
 				return fmt.Errorf("missing aggregation parameter: %s", p)
 			}

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -16,7 +16,10 @@
 
 package aggsquery
 
-import "github.com/teletrace/teletrace/pkg/model"
+import (
+	"fmt"
+	"github.com/teletrace/teletrace/pkg/model"
+)
 
 type HistogramRequest struct {
 	Timeframe     *model.Timeframe       `json:"timeframe"`
@@ -53,4 +56,12 @@ type Bucket struct {
 type Histogram struct {
 	HistogramLabel string   `json:"histogramLabel"`
 	Buckets        []Bucket `json:"buckets"`
+}
+
+func (sr *HistogramRequest) Validate() error {
+	if (sr.Timeframe.EndTime < sr.Timeframe.StartTime) && (sr.Timeframe.EndTime != 0) {
+		return fmt.Errorf("endTime cannot be smaller than startTime")
+	}
+
+	return nil
 }

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -38,11 +38,14 @@ const (
 	PERCENTILES    AggregationFunction = "PERCENTILES"
 )
 
+type AggregationParameters map[string]any
+
 type Aggregation struct {
-	Func      AggregationFunction `json:"func"`
-	GroupBy   string              `json:"groupBy,omitempty"`
-	MaxGroups int                 `json:"maxGroups,omitempty"`
-	Key       string              `json:"key,omitempty"`
+	Func                  AggregationFunction   `json:"func"`
+	GroupBy               string                `json:"groupBy,omitempty"`
+	MaxGroups             int                   `json:"maxGroups,omitempty"`
+	Key                   string                `json:"key,omitempty"`
+	AggregationParameters AggregationParameters `json:"aggregationParameters,omitempty"`
 }
 
 type HistogramsResponse struct {

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package aggsquery
 
 import "github.com/teletrace/teletrace/pkg/model"

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -39,9 +39,10 @@ const (
 )
 
 type Aggregation struct {
-	Func    AggregationFunction `json:"func"`
-	GroupBy string              `json:"groupBy,omitempty"`
-	Key     string              `json:"key,omitempty"`
+	Func      AggregationFunction `json:"func"`
+	GroupBy   string              `json:"groupBy,omitempty"`
+	MaxGroups int                 `json:"maxGroups,omitempty"`
+	Key       string              `json:"key,omitempty"`
 }
 
 type HistogramsResponse struct {

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -39,10 +39,9 @@ const (
 )
 
 type Aggregation struct {
-	Func      AggregationFunction `json:"func"`
-	GroupBy   string              `json:"groupBy,omitempty"`
-	MaxGroups int                 `json:"maxGroups,omitempty"`
-	Key       string              `json:"key,omitempty"`
+	Func    AggregationFunction `json:"func"`
+	GroupBy string              `json:"groupBy,omitempty"`
+	Key     string              `json:"key,omitempty"`
 }
 
 type HistogramsResponse struct {

--- a/pkg/model/aggsquery/v1/aggs_query.go
+++ b/pkg/model/aggsquery/v1/aggs_query.go
@@ -18,6 +18,7 @@ package aggsquery
 
 import (
 	"fmt"
+
 	"github.com/teletrace/teletrace/pkg/model"
 )
 

--- a/pkg/spanreader/interfaces.go
+++ b/pkg/spanreader/interfaces.go
@@ -18,6 +18,7 @@ package spanreader
 
 import (
 	"context"
+
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"

--- a/pkg/spanreader/interfaces.go
+++ b/pkg/spanreader/interfaces.go
@@ -31,7 +31,7 @@ type SpanReader interface {
 	GetAvailableTags(ctx context.Context, r tagsquery.GetAvailableTagsRequest) (*tagsquery.GetAvailableTagsResponse, error)
 	GetTagsValues(ctx context.Context, r tagsquery.TagValuesRequest, tags []string) (map[string]*tagsquery.TagValuesResponse, error)
 	GetTagsStatistics(ctx context.Context, r tagsquery.TagStatisticsRequest, tag string) (*tagsquery.TagStatisticsResponse, error)
-	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (*aggsquery.HistogramResponse, error)
+	GetHistograms(ctx context.Context, req aggsquery.HistogramsRequest) (*aggsquery.HistogramsResponse, error)
 	GetSystemId(ctx context.Context, r metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error)
 	SetSystemId(ctx context.Context, r metadata.SetSystemIdRequest) (*metadata.SetSystemIdResponse, error)
 }

--- a/pkg/spanreader/interfaces.go
+++ b/pkg/spanreader/interfaces.go
@@ -18,6 +18,7 @@ package spanreader
 
 import (
 	"context"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
@@ -30,6 +31,7 @@ type SpanReader interface {
 	GetAvailableTags(ctx context.Context, r tagsquery.GetAvailableTagsRequest) (*tagsquery.GetAvailableTagsResponse, error)
 	GetTagsValues(ctx context.Context, r tagsquery.TagValuesRequest, tags []string) (map[string]*tagsquery.TagValuesResponse, error)
 	GetTagsStatistics(ctx context.Context, r tagsquery.TagStatisticsRequest, tag string) (*tagsquery.TagStatisticsResponse, error)
+	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (*aggsquery.HistogramResponse, error)
 	GetSystemId(ctx context.Context, r metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error)
 	SetSystemId(ctx context.Context, r metadata.SetSystemIdRequest) (*metadata.SetSystemIdResponse, error)
 }

--- a/pkg/spanreader/mock/spanreader.go
+++ b/pkg/spanreader/mock/spanreader.go
@@ -18,6 +18,7 @@ package mock
 
 import (
 	"context"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
@@ -31,6 +32,48 @@ import (
 )
 
 type spanReader struct{}
+
+func (sr spanReader) GetHistograms(ctx context.Context, req aggsquery.HistogramsRequest) (*aggsquery.HistogramsResponse, error) {
+	return &aggsquery.HistogramsResponse{
+		Histograms: []aggsquery.Histogram{
+			{
+				HistogramLabel: "errors_distinct_count",
+				Buckets: []aggsquery.Bucket{
+					{
+						BucketKey: 1684222200000000000,
+						Data: []map[string]any{
+							{
+								"count": 76,
+								"key":   500,
+							},
+							{
+								"count": 35,
+								"key":   404,
+							},
+						},
+					},
+					{
+						BucketKey: 1684222800000000000,
+						Data: []map[string]any{
+							{
+								"count": 1,
+								"key":   403,
+							},
+							{
+								"count": 19,
+								"key":   308,
+							},
+						},
+					},
+					{
+						BucketKey: 1684223400000000000,
+						Data:      []map[string]any{},
+					},
+				},
+			},
+		},
+	}, nil
+}
 
 func (sr spanReader) Search(ctx context.Context, r spansquery.SearchRequest) (*spansquery.SearchResponse, error) {
 	spans := []*internalspan.InternalSpan{spanformatutiltests.GenInternalSpan(nil, nil, nil)}

--- a/pkg/spanreader/mock/spanreader.go
+++ b/pkg/spanreader/mock/spanreader.go
@@ -76,7 +76,8 @@ func (sr spanReader) GetHistograms(ctx context.Context, req aggsquery.Histograms
 						BucketKey: 1684223400000000000,
 						Data: map[string]any{
 							aggsquery.TotalCountField: 0,
-							aggsquery.SubBucketsField: []map[string]any{}},
+							aggsquery.SubBucketsField: []map[string]any{},
+						},
 					},
 				},
 			},

--- a/pkg/spanreader/mock/spanreader.go
+++ b/pkg/spanreader/mock/spanreader.go
@@ -18,6 +18,7 @@ package mock
 
 import (
 	"context"
+
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"

--- a/pkg/spanreader/mock/spanreader.go
+++ b/pkg/spanreader/mock/spanreader.go
@@ -42,33 +42,41 @@ func (sr spanReader) GetHistograms(ctx context.Context, req aggsquery.Histograms
 				Buckets: []aggsquery.Bucket{
 					{
 						BucketKey: 1684222200000000000,
-						Data: []map[string]any{
-							{
-								"count": 76,
-								"key":   500,
-							},
-							{
-								"count": 35,
-								"key":   404,
+						Data: map[string]any{
+							aggsquery.TotalCountField: 153,
+							aggsquery.SubBucketsField: []map[string]any{
+								{
+									"count": 76,
+									"key":   500,
+								},
+								{
+									"count": 35,
+									"key":   404,
+								},
 							},
 						},
 					},
 					{
 						BucketKey: 1684222800000000000,
-						Data: []map[string]any{
-							{
-								"count": 1,
-								"key":   403,
-							},
-							{
-								"count": 19,
-								"key":   308,
+						Data: map[string]any{
+							aggsquery.TotalCountField: 168,
+							aggsquery.SubBucketsField: []map[string]any{
+								{
+									"count": 83,
+									"key":   500,
+								},
+								{
+									"count": 9,
+									"key":   308,
+								},
 							},
 						},
 					},
 					{
 						BucketKey: 1684223400000000000,
-						Data:      []map[string]any{},
+						Data: map[string]any{
+							aggsquery.TotalCountField: 0,
+							aggsquery.SubBucketsField: []map[string]any{}},
 					},
 				},
 			},

--- a/plugin/spanreader/es/aggscontroller/aggs_controller.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/elastic/go-elasticsearch/v8"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types"

--- a/plugin/spanreader/es/aggscontroller/aggs_controller.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller.go
@@ -95,7 +95,9 @@ func buildHistogramsRequest(req aggsquery.HistogramsRequest) (*search.Request, e
 		aggregations[label] = histogramAgg
 
 		// Add a sub aggregation
-		handler.AddSubAggregation(label, agg, histogramAgg)
+		if err := handler.AddSubAggregation(label, agg, histogramAgg); err != nil {
+			return nil, fmt.Errorf("an error occurred while building aggregations: %+v", err)
+		}
 	}
 
 	request := builder.Aggregations(aggregations).Build()

--- a/plugin/spanreader/es/aggscontroller/aggs_controller.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller.go
@@ -1,0 +1,108 @@
+package aggscontroller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+	"github.com/teletrace/teletrace/plugin/spanreader/es/aggscontroller/histogram"
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es/utils"
+	"go.uber.org/zap"
+)
+
+type aggsController struct {
+	client *elasticsearch.TypedClient
+	idx    string
+}
+
+func NewAggsController(logger *zap.Logger, client *elasticsearch.TypedClient, idx string) (AggsController, error) {
+	return &aggsController{
+		client: client,
+		idx:    idx,
+	}, nil
+}
+
+func (a *aggsController) GetHistogram(
+	ctx context.Context, req aggsquery.HistogramRequest,
+) (aggsquery.HistogramResponse, error) {
+	return a.performGetHistogramRequest(ctx, req, histogram.WithMilliSecTimestampAsNanoSec())
+}
+
+func (a *aggsController) performGetHistogramRequest(
+	ctx context.Context,
+	request aggsquery.HistogramRequest,
+	opts ...histogram.HistogramsParseOption,
+) (aggsquery.HistogramResponse, error) {
+	req, err := buildHistogramRequest(request)
+	if err != nil {
+		return aggsquery.HistogramResponse{}, fmt.Errorf("failed to build query: %s", err)
+	}
+
+	res, err := a.client.API.Search().Request(req).Index(a.idx).Do(ctx)
+	if err != nil {
+		return aggsquery.HistogramResponse{}, fmt.Errorf("failed to perform search: %s", err)
+	}
+
+	var body map[string]any
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return aggsquery.HistogramResponse{}, fmt.Errorf("failed parsing the response body: %s", err)
+	}
+
+	return a.parseHistogramResponse(body, request, opts)
+}
+
+func buildHistogramRequest(req aggsquery.HistogramRequest) (*search.Request, error) {
+	builder := search.NewRequestBuilder()
+	timeframeFilters := spanreaderes.CreateTimeframeFilters(req.Timeframe)
+	filters := append(req.SearchFilters, timeframeFilters...)
+	_, err := spanreaderes.BuildQuery(builder, filters...)
+	if err != nil {
+		return nil, err
+	}
+	builder.Size(0)
+
+	aggregations := make(map[string]*types.AggregationContainerBuilder)
+
+	for label, agg := range req.Aggregations {
+		handler := histogram.AggregationFunctionToHandler[agg.Func]
+
+		// Create a new histogram aggregation
+		histogramAgg := types.NewAggregationContainerBuilder().Histogram(
+			types.NewHistogramAggregationBuilder().Field(types.Field(req.IntervalKey)).Interval(req.Interval),
+		)
+
+		// Add a sub aggregation
+		handler.AddSubAggregation(label, agg, histogramAgg)
+
+		// Add the histogram as a sub aggregation of the existing aggregation
+		aggregations[label] = histogramAgg
+	}
+
+	request := builder.Aggregations(aggregations).Build()
+	return request, nil
+}
+
+func (a *aggsController) parseHistogramResponse(
+	body map[string]any, request aggsquery.HistogramRequest, opts []histogram.HistogramsParseOption,
+) (aggsquery.HistogramResponse, error) {
+	result := aggsquery.HistogramResponse{
+		Histograms: []aggsquery.Histogram{},
+	}
+
+	if aggregations, ok := body["aggregations"].(map[string]any); ok {
+		for label, aggregation := range request.Aggregations {
+			handler := histogram.AggregationFunctionToHandler[aggregation.Func]
+			h := handler.GetHistogram(aggregations, label)
+			result.Histograms = append(result.Histograms, h)
+		}
+	}
+
+	for _, opt := range opts {
+		opt(request.IntervalKey, result.Histograms)
+	}
+
+	return result, nil
+}

--- a/plugin/spanreader/es/aggscontroller/aggs_controller.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package aggscontroller
 
 import (

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -19,8 +19,9 @@ package aggscontroller
 import (
 	"bytes"
 	"encoding/json"
-	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 	"testing"
+
+	spansquery "github.com/teletrace/teletrace/pkg/model/spansquery/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/teletrace/teletrace/pkg/model"

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -105,7 +105,7 @@ func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
 			"latency_percentiles": {
 				Func: aggsquery.PERCENTILES,
 				Key:  "externalFields.durationNano",
-				AggregationParameters: map[aggsquery.AggregationParameter]any{
+				AggFunctionParams: map[aggsquery.AggregationParameter]any{
 					"percentiles": []any{50, 75, 90, 95, 99},
 				},
 			},

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -103,7 +103,7 @@ func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
 			"latency_percentiles": {
 				Func: aggsquery.PERCENTILES,
 				Key:  "externalFields.durationNano",
-				AggregationParameters: map[string]any{
+				AggregationParameters: map[aggsquery.AggregationParameter]any{
 					"percentiles": []any{50, 75, 90, 95, 99},
 				},
 			},

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -110,7 +110,6 @@ func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
 	body := make(map[string]any)
 	_ = json.NewDecoder(buffer).Decode(&body)
 
-	// Act
 	ac := aggsController{}
 	result, err := ac.parseHistogramsResponse(body, req, nil)
 	if err != nil {

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -103,6 +103,9 @@ func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
 			"latency_percentiles": {
 				Func: aggsquery.PERCENTILES,
 				Key:  "externalFields.durationNano",
+				AggregationParameters: map[string]any{
+					"percentiles": []any{50, 75, 90, 95, 99},
+				},
 			},
 		},
 	}

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -19,10 +19,11 @@ package aggscontroller
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/teletrace/teletrace/pkg/model"
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
-	"testing"
 )
 
 func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aggscontroller
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+	"testing"
+)
+
+func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
+	responseContent := `
+	{
+	  "took": 1435,
+	  "timed_out": false,
+	  "_shards": {
+		"total": 87,
+		"successful": 87,
+		"skipped": 0,
+		"failed": 0
+	  },
+	  "hits": {
+		"total": {
+		  "value": 10000,
+		  "relation": "gte"
+		},
+		"max_score": null,
+		"hits": []
+	  },
+	  "aggregations": {
+		"latency_percentiles": {
+		  "buckets": [
+			{
+			  "key": 1684231800000,
+			  "doc_count": 9778,
+			  "latency_percentiles": {
+				"values": {
+				  "50.0": 6,
+				  "75.0": 13.782178217821782,
+				  "90.0": 26,
+				  "95.0": 67.26484848484854,
+				  "99.0": 43482.37333333334
+				}
+			  }
+			},
+			{
+			  "key": 1684232400000,
+			  "doc_count": 9921,
+			  "latency_percentiles": {
+				"values": {
+				  "50.0": 5.410714285714286,
+				  "75.0": 13,
+				  "90.0": 24,
+				  "95.0": 65.13311688311666,
+				  "99.0": 35579.48933333333
+				}
+			  }
+			},
+			{
+			  "key": 1684233000000,
+			  "doc_count": 260,
+			  "latency_percentiles": {
+				"values": {
+				  "50.0": 5,
+				  "75.0": 12.5,
+				  "90.0": 21,
+				  "95.0": 30.5,
+				  "99.0": 48.89999999999998
+				}
+			  }
+			}	
+	   	  ]
+	   }
+     }
+	}`
+
+	req := aggsquery.HistogramsRequest{
+		Timeframe: &model.Timeframe{
+			StartTime: 0,
+			EndTime:   0,
+		},
+		Interval:    600000,
+		IntervalKey: "span.startTimeUnixNano",
+		Aggregations: map[string]aggsquery.Aggregation{
+			"latency_percentiles": {
+				Func: aggsquery.PERCENTILES,
+				Key:  "externalFields.durationNano",
+			},
+		},
+	}
+
+	buffer := bytes.NewBufferString(responseContent)
+	body := make(map[string]any)
+	_ = json.NewDecoder(buffer).Decode(&body)
+
+	// Act
+	ac := aggsController{}
+	result, err := ac.parseHistogramsResponse(body, req, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expectedFirstBucket50thPercentileValue float64 = 6
+
+	// Assert
+	assert.NotNil(t, result)
+	assert.Len(t, result.Histograms, 1)
+	assert.Equal(t, "latency_percentiles", result.Histograms[0].HistogramLabel)
+	assert.Len(t, result.Histograms[0].Buckets, 3)
+	assert.Len(t, result.Histograms[0].Buckets[0].Data, 5)
+	assert.Equal(t, result.Histograms[0].Buckets[0].Data.(map[string]any)["50.0"], expectedFirstBucket50thPercentileValue)
+}

--- a/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
+++ b/plugin/spanreader/es/aggscontroller/aggs_controller_test.go
@@ -86,7 +86,7 @@ func Test_ParseHistogramsResponse_ValidResponse(t *testing.T) {
 				  "99.0": 48.89999999999998
 				}
 			  }
-			}	
+			}
 	   	  ]
 	   }
      }

--- a/plugin/spanreader/es/aggscontroller/histogram/handler.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/handler.go
@@ -143,6 +143,8 @@ func (h *percentilesHandler) AddSubAggregation(
 	for _, p := range h.GetSupportedParameters() {
 		if param, ok := aggregation.AggregationParameters[p]; ok {
 			parameters[p] = param
+		} else {
+			return fmt.Errorf("missing aggregation parameter: %s", p)
 		}
 	}
 

--- a/plugin/spanreader/es/aggscontroller/histogram/handler.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/handler.go
@@ -141,11 +141,11 @@ func (h *percentilesHandler) AddSubAggregation(
 
 	// Search for aggregation parameters
 	for _, p := range h.GetSupportedParameters() {
-		if param, ok := aggregation.AggregationParameters[p]; ok {
-			parameters[p] = param
-		} else {
+		param, ok := aggregation.AggregationParameters[p]
+		if !ok {
 			return fmt.Errorf("missing aggregation parameter: %s", p)
 		}
+		parameters[p] = param
 	}
 
 	// Convert the 'percentiles' parameter to a float64 array

--- a/plugin/spanreader/es/aggscontroller/histogram/handler.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/handler.go
@@ -1,0 +1,90 @@
+package histogram
+
+import (
+	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+)
+
+var AggregationFunctionToHandler = map[aggsquery.AggregationFunction]Handler{
+	aggsquery.COUNT:          &countHandler{},
+	aggsquery.DISTINCT_COUNT: &distinctCountHandler{},
+	aggsquery.PERCENTILES:    &percentilesHandler{},
+}
+
+type Handler interface {
+	AddSubAggregation(label string, aggregation aggsquery.Aggregation, aggs *types.AggregationContainerBuilder)
+	GetHistogram(aggs map[string]any, label string) aggsquery.Histogram
+}
+
+type baseHandler struct{}
+
+func (h *baseHandler) GetHistogram(aggs map[string]any, label string) aggsquery.Histogram {
+	// Extract the relevant data from the aggs map
+	resultBuckets := aggs[label].(map[string]any)["buckets"].([]map[string]any)
+
+	var buckets []aggsquery.Bucket
+	// For each bucket in the aggregation:
+	for _, resultBucket := range resultBuckets {
+		bucket := aggsquery.Bucket{
+			BucketKey: resultBucket["key"],
+			Data:      resultBucket["doc_count"],
+		}
+
+		buckets = append(buckets, bucket)
+	}
+
+	return aggsquery.Histogram{
+		HistogramLabel: label,
+		Buckets:        buckets,
+	}
+}
+
+type countHandler struct {
+	baseHandler
+}
+
+func (h *countHandler) AddSubAggregation(
+	label string, _ aggsquery.Aggregation, histogramAgg *types.AggregationContainerBuilder,
+) {
+	valueCountAgg := types.NewAggregationContainerBuilder().ValueCount(
+		types.NewValueCountAggregationBuilder().Field("span.spanId.keyword"),
+	)
+
+	histogramAgg.Aggregations(
+		map[string]*types.AggregationContainerBuilder{label: valueCountAgg},
+	)
+}
+
+type distinctCountHandler struct {
+	baseHandler
+}
+
+func (h *distinctCountHandler) AddSubAggregation(
+	label string, aggregation aggsquery.Aggregation, histogramAgg *types.AggregationContainerBuilder,
+) {
+	termsAgg := types.NewAggregationContainerBuilder().Terms(
+		types.NewTermsAggregationBuilder().Field(types.Field(aggregation.GroupBy)),
+	)
+
+	histogramAgg.Aggregations(
+		map[string]*types.AggregationContainerBuilder{label: termsAgg},
+	)
+}
+
+type percentilesHandler struct {
+	baseHandler
+}
+
+func (h *percentilesHandler) AddSubAggregation(
+	label string, aggregation aggsquery.Aggregation, histogramAgg *types.AggregationContainerBuilder,
+) {
+	percentilesAgg := types.NewAggregationContainerBuilder().Percentiles(
+		types.NewPercentilesAggregationBuilder().Field(types.Field(aggregation.Key)).Percents(
+			[]float64{50, 75, 90, 95, 99}...,
+		),
+	)
+
+	histogramAgg.Aggregations(
+		map[string]*types.AggregationContainerBuilder{label: percentilesAgg},
+	)
+}

--- a/plugin/spanreader/es/aggscontroller/histogram/handler.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/handler.go
@@ -131,7 +131,7 @@ type percentilesHandler struct{}
 func (h *percentilesHandler) AddSubAggregation(
 	label string, aggregation aggsquery.Aggregation, histogramAgg *types.AggregationContainerBuilder,
 ) error {
-	percentiles := aggregation.AggregationParameters[aggsquery.PERCENTILES_PARAM].([]any)
+	percentiles := aggregation.AggFunctionParams[aggsquery.PERCENTILES_PARAM].([]any)
 
 	// Convert the 'percentiles' parameter to a float64 array
 	percentilesFloat64 := make([]float64, len(percentiles))

--- a/plugin/spanreader/es/aggscontroller/histogram/handler.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/handler.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package histogram
 
 import (

--- a/plugin/spanreader/es/aggscontroller/histogram/option.go
+++ b/plugin/spanreader/es/aggscontroller/histogram/option.go
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package histogram
+
+import (
+	"github.com/teletrace/teletrace/pkg/model"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+	spanreaderes "github.com/teletrace/teletrace/plugin/spanreader/es/utils"
+)
+
+type HistogramsParseOption func(intervalKey string, histograms []aggsquery.Histogram)
+
+func WithMilliSecTimestampAsNanoSec() HistogramsParseOption {
+	return func(intervalKey string, histograms []aggsquery.Histogram) {
+		if spanreaderes.IsConvertedTimestamp(model.FilterKey(intervalKey)) {
+			for _, histogram := range histograms {
+				for i := range histogram.Buckets {
+					histogram.Buckets[i].BucketKey = spanreaderes.MilliToNanoFloat64(histogram.Buckets[i].BucketKey.(float64))
+				}
+			}
+		}
+	}
+}

--- a/plugin/spanreader/es/aggscontroller/interface.go
+++ b/plugin/spanreader/es/aggscontroller/interface.go
@@ -22,5 +22,5 @@ import (
 )
 
 type AggsController interface {
-	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (*aggsquery.HistogramResponse, error)
+	GetHistograms(ctx context.Context, req aggsquery.HistogramsRequest) (*aggsquery.HistogramsResponse, error)
 }

--- a/plugin/spanreader/es/aggscontroller/interface.go
+++ b/plugin/spanreader/es/aggscontroller/interface.go
@@ -22,5 +22,5 @@ import (
 )
 
 type AggsController interface {
-	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (aggsquery.HistogramResponse, error)
+	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (*aggsquery.HistogramResponse, error)
 }

--- a/plugin/spanreader/es/aggscontroller/interface.go
+++ b/plugin/spanreader/es/aggscontroller/interface.go
@@ -18,6 +18,7 @@ package aggscontroller
 
 import (
 	"context"
+
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 )
 

--- a/plugin/spanreader/es/aggscontroller/interface.go
+++ b/plugin/spanreader/es/aggscontroller/interface.go
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2022 Cisco Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aggscontroller
+
+import (
+	"context"
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+)
+
+type AggsController interface {
+	GetHistogram(ctx context.Context, req aggsquery.HistogramRequest) (aggsquery.HistogramResponse, error)
+}

--- a/plugin/spanreader/es/span_reader.go
+++ b/plugin/spanreader/es/span_reader.go
@@ -106,7 +106,7 @@ func (sr *spanReader) GetHistogram(
 ) (*aggsquery.HistogramResponse, error) {
 	res, err := sr.aggsController.GetHistogram(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("GetTagsStatistics failed with error: %+v", err)
+		return nil, fmt.Errorf("GetHistogram failed with error: %+v", err)
 	}
 
 	return res, nil

--- a/plugin/spanreader/es/span_reader.go
+++ b/plugin/spanreader/es/span_reader.go
@@ -101,12 +101,12 @@ func (sr *spanReader) GetTagsStatistics(ctx context.Context, r tagsquery.TagStat
 	return res, nil
 }
 
-func (sr *spanReader) GetHistogram(
-	ctx context.Context, req aggsquery.HistogramRequest,
-) (*aggsquery.HistogramResponse, error) {
-	res, err := sr.aggsController.GetHistogram(ctx, req)
+func (sr *spanReader) GetHistograms(
+	ctx context.Context, req aggsquery.HistogramsRequest,
+) (*aggsquery.HistogramsResponse, error) {
+	res, err := sr.aggsController.GetHistograms(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("GetHistogram failed with error: %+v", err)
+		return nil, fmt.Errorf("GetHistograms failed with error: %+v", err)
 	}
 
 	return res, nil

--- a/plugin/spanreader/es/span_reader.go
+++ b/plugin/spanreader/es/span_reader.go
@@ -19,6 +19,7 @@ package spanreaderes
 import (
 	"context"
 	"fmt"
+
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"github.com/teletrace/teletrace/plugin/spanreader/es/aggscontroller"
 

--- a/plugin/spanreader/opensearch/span_reader.go
+++ b/plugin/spanreader/opensearch/span_reader.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
+
 	"github.com/teletrace/teletrace/pkg/model"
 
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
@@ -87,6 +89,12 @@ func (sr *spanReader) GetTagsStatistics(ctx context.Context, req tagsquery.TagSt
 	}
 
 	return res, nil
+}
+
+func (sr *spanReader) GetHistograms(
+	ctx context.Context, req aggsquery.HistogramsRequest,
+) (*aggsquery.HistogramsResponse, error) {
+	return nil, fmt.Errorf("Not implemented method")
 }
 
 func (sr *spanReader) GetSystemId(ctx context.Context, req metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error) {

--- a/plugin/spanreader/sqlite/span_reader.go
+++ b/plugin/spanreader/sqlite/span_reader.go
@@ -208,9 +208,9 @@ func (sr *spanReader) GetTagValues(ctx context.Context, r tagsquery.TagValuesReq
 		Values: currentTagValues,
 	}, nil
 }
-func (sr *spanReader) GetHistogram(
-	ctx context.Context, req aggsquery.HistogramRequest,
-) (*aggsquery.HistogramResponse, error) {
+func (sr *spanReader) GetHistograms(
+	ctx context.Context, req aggsquery.HistogramsRequest,
+) (*aggsquery.HistogramsResponse, error) {
 	return nil, fmt.Errorf("Not implemented method")
 }
 func (sr *spanReader) GetSystemId(ctx context.Context, r metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error) {

--- a/plugin/spanreader/sqlite/span_reader.go
+++ b/plugin/spanreader/sqlite/span_reader.go
@@ -19,7 +19,7 @@ package sqlitespanreader
 import (
 	"context"
 	"fmt"
-
+	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
 	"github.com/teletrace/teletrace/pkg/spanreader"
@@ -208,7 +208,11 @@ func (sr *spanReader) GetTagValues(ctx context.Context, r tagsquery.TagValuesReq
 		Values: currentTagValues,
 	}, nil
 }
-
+func (sr *spanReader) GetHistogram(
+	ctx context.Context, req aggsquery.HistogramRequest,
+) (*aggsquery.HistogramResponse, error) {
+	return nil, fmt.Errorf("Not implemented method")
+}
 func (sr *spanReader) GetSystemId(ctx context.Context, r metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error) {
 	return nil, fmt.Errorf("Not implemented method")
 }

--- a/plugin/spanreader/sqlite/span_reader.go
+++ b/plugin/spanreader/sqlite/span_reader.go
@@ -19,6 +19,7 @@ package sqlitespanreader
 import (
 	"context"
 	"fmt"
+
 	"github.com/teletrace/teletrace/pkg/model/aggsquery/v1"
 	"github.com/teletrace/teletrace/pkg/model/metadata/v1"
 	"github.com/teletrace/teletrace/pkg/model/tagsquery/v1"
@@ -208,11 +209,13 @@ func (sr *spanReader) GetTagValues(ctx context.Context, r tagsquery.TagValuesReq
 		Values: currentTagValues,
 	}, nil
 }
+
 func (sr *spanReader) GetHistograms(
 	ctx context.Context, req aggsquery.HistogramsRequest,
 ) (*aggsquery.HistogramsResponse, error) {
 	return nil, fmt.Errorf("Not implemented method")
 }
+
 func (sr *spanReader) GetSystemId(ctx context.Context, r metadata.GetSystemIdRequest) (*metadata.GetSystemIdResponse, error) {
 	return nil, fmt.Errorf("Not implemented method")
 }


### PR DESCRIPTION
## What this PR does:
- Implements the "histograms" API defined in #1592
- Implements the Elasticsearch implementation for the histograms API
- Tests the histograms API

## Invocation examples:

**errors_distinct_count**:

`curl --location --request POST 'http://localhost:8080/v1/histograms' \
--header 'Content-Type: application/json' \
--data-raw '{
    "timeframe": {
        "startTimeUnixNanoSec": 0,
        "endTimeUnixNanoSec": 0
    },
    "filters": [
        {
            "keyValueFilter": {
                "key": "span.status.code",
                "operator":"in",
                "value": ["Error"]
            }
        }
    ],
    "interval": 600000,
    "intervalKey": "span.startTimeUnixNano",
    "aggregations": {
        "errors_distinct_count": {
            "func": "DISTINCT_COUNT",
            "groupBy": "span.attributes.http.status_code",
            "maxGroups": 5
        }    
    }
}'`

![Screenshot 2023-05-17 at 13 33 07](https://github.com/teletrace/teletrace/assets/44731477/064a8254-c13a-4dfb-a0c9-c079a913ebab)



**latency_percentiles**:

`curl --location --request POST 'http://localhost:8080/v1/histograms' \
--header 'Content-Type: application/json' \
--data-raw '{
    "timeframe": {
        "startTimeUnixNanoSec": 0,
        "endTimeUnixNanoSec": 0
    },
    "interval": 600000,
    "intervalKey": "span.startTimeUnixNano",
    "aggregations": {
        "latency_percentiles": {
            "func": "PERCENTILES",
            "key": "externalFields.durationNano",
            "aggregationParameters": {
                "percentiles": [50, 75, 90, 95, 99]
            }
        }    
    }
}'`

![Screenshot 2023-05-17 at 10 03 29](https://github.com/teletrace/teletrace/assets/44731477/6fe2560d-ea9c-4437-8c56-705a34a1f53a)

**requests_count**:

`curl --location --request POST 'http://localhost:8080/v1/histograms' \
--header 'Content-Type: application/json' \
--data-raw '{
    "timeframe": {
        "startTimeUnixNanoSec": 0,
        "endTimeUnixNanoSec": 0
    },
    "filters": [
        {
            "keyValueFilter": {
                "key": "span.kind",
                "operator":"in",
                "value": ["Client"]
            }
        }
    ],
    "interval": 600000,
    "intervalKey": "span.startTimeUnixNano",
    "aggregations": {
        "requests_count": {
            "func": "COUNT"
        }    
    }
}'`

![Screenshot 2023-05-17 at 10 03 46](https://github.com/teletrace/teletrace/assets/44731477/949162a4-ec85-443d-a7d7-25e13f7af9ef)


## Which issue(s) this PR fixes:

Fixes #1600

## Checklist

- [X] Tests updated
