### PR TITLE
feat: add spansearch hash storage

### DIFF
--- a/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
+++ b/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
@@ -51,12 +51,11 @@ const startTimeToOption = (startTimeUnixNanoSec: number): RelativeTimeFrame => {
 
   const matchedOption = options.reverse().find((option) => {
     const optionOffsetMillis = getOffsetInMillis(option.offsetRange);
-    return (nowMillis - startTimeMillis) >= optionOffsetMillis;
+    return nowMillis - startTimeMillis >= optionOffsetMillis;
   });
 
   return matchedOption || options[0]; // Return the matched option or the default 1H option
 };
-
 
 export const TimeFrameSelector = () => {
   const timeframeState = useSpanSearchStore((state) => state.timeframeState);
@@ -72,9 +71,12 @@ export const TimeFrameSelector = () => {
     options[0]
   );
 
-  const selectionToDisplay = timeframeState.currentTimeframe.isRelative ? startTimeToOption(timeframeState.currentTimeframe.startTimeUnixNanoSec) : customOption;
-  
-  const [isSelected, setIsSelected] = useState<TimeFrameTypes>(selectionToDisplay);
+  const selectionToDisplay = timeframeState.currentTimeframe.isRelative
+    ? startTimeToOption(timeframeState.currentTimeframe.startTimeUnixNanoSec)
+    : customOption;
+
+  const [isSelected, setIsSelected] =
+    useState<TimeFrameTypes>(selectionToDisplay);
 
   const getRelativeStartTime = (timestamp: number, offset: string) => {
     const datetime =

--- a/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
+++ b/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
@@ -23,22 +23,29 @@ import { formatNanoToTimeString, msToNano, nanoToMs } from "@/utils/format";
 import { useSpanSearchStore } from "../../stores/spanSearchStore";
 import { DateTimeSelector } from "../DateTimeSelector/DateTimeSelector";
 
+enum Offset {
+  OneHour = "1h",
+  OneDay = "1d",
+  ThreeDays = "3d",
+  OneWeek = "1w",
+}
+
 const options: RelativeTimeFrame[] = [
-  { label: "1H", offsetRange: "1h", relativeTo: "now" },
-  { label: "1D", offsetRange: "1d", relativeTo: "now" },
-  { label: "3D", offsetRange: "3d", relativeTo: "now" },
-  { label: "1W", offsetRange: "1w", relativeTo: "now" },
+  { label: "1H", offsetRange: Offset.OneHour, relativeTo: "now" },
+  { label: "1D", offsetRange: Offset.OneDay, relativeTo: "now" },
+  { label: "3D", offsetRange: Offset.ThreeDays, relativeTo: "now" },
+  { label: "1W", offsetRange: Offset.OneWeek, relativeTo: "now" },
 ];
 
-const getOffsetInMillis = (offset: string): number => {
+const getOffsetInMillis = (offset: Offset): number => {
   switch (offset) {
-    case "1h":
+    case Offset.OneHour:
       return 60 * 60 * 1000;
-    case "1d":
+    case Offset.OneDay:
       return 24 * 60 * 60 * 1000;
-    case "3d":
+    case Offset.ThreeDays:
       return 3 * 24 * 60 * 60 * 1000;
-    case "1w":
+    case Offset.OneWeek:
       return 7 * 24 * 60 * 60 * 1000;
     default:
       return 0;
@@ -176,7 +183,7 @@ export const TimeFrameSelector = () => {
 type RelativeTimeFrame = {
   label: string;
   relativeTo: string;
-  offsetRange: string;
+  offsetRange: Offset;
 };
 
 function isRelativeTimeFrame(

--- a/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
+++ b/web/src/features/search/components/TimeFrameSelector/TimeFrameSelector.tsx
@@ -30,6 +30,34 @@ const options: RelativeTimeFrame[] = [
   { label: "1W", offsetRange: "1w", relativeTo: "now" },
 ];
 
+const getOffsetInMillis = (offset: string): number => {
+  switch (offset) {
+    case "1h":
+      return 60 * 60 * 1000;
+    case "1d":
+      return 24 * 60 * 60 * 1000;
+    case "3d":
+      return 3 * 24 * 60 * 60 * 1000;
+    case "1w":
+      return 7 * 24 * 60 * 60 * 1000;
+    default:
+      return 0;
+  }
+};
+
+const startTimeToOption = (startTimeUnixNanoSec: number): RelativeTimeFrame => {
+  const startTimeMillis = startTimeUnixNanoSec / 1e6;
+  const nowMillis = Date.now();
+
+  const matchedOption = options.reverse().find((option) => {
+    const optionOffsetMillis = getOffsetInMillis(option.offsetRange);
+    return (nowMillis - startTimeMillis) >= optionOffsetMillis;
+  });
+
+  return matchedOption || options[0]; // Return the matched option or the default 1H option
+};
+
+
 export const TimeFrameSelector = () => {
   const timeframeState = useSpanSearchStore((state) => state.timeframeState);
 
@@ -43,7 +71,10 @@ export const TimeFrameSelector = () => {
   const [previousSelected, setPreviousSelected] = useState<TimeFrameTypes>(
     options[0]
   );
-  const [isSelected, setIsSelected] = useState<TimeFrameTypes>(options[0]);
+
+  const selectionToDisplay = timeframeState.currentTimeframe.isRelative ? startTimeToOption(timeframeState.currentTimeframe.startTimeUnixNanoSec) : customOption;
+  
+  const [isSelected, setIsSelected] = useState<TimeFrameTypes>(selectionToDisplay);
 
   const getRelativeStartTime = (timestamp: number, offset: string) => {
     const datetime =

--- a/web/src/features/search/stores/spanSearchStore.ts
+++ b/web/src/features/search/stores/spanSearchStore.ts
@@ -240,7 +240,7 @@ export const useSpanSearchStore = create<
       // By default, zustand's merge function is shallow and it causes hydration issues
       // when loading nested objects from state.
       // We solved this issue by "teaching" zustand how to go a level deeper when merging this state.
-  
+
       merge: (persisted, current) => ({
         ...current,
         timeframeState: {

--- a/web/src/features/search/stores/spanSearchStore.ts
+++ b/web/src/features/search/stores/spanSearchStore.ts
@@ -239,10 +239,8 @@ export const useSpanSearchStore = create<
       storage: createJSONStorage(() => hashStorage),
       // By default, zustand's merge function is shallow and it causes hydration issues
       // when loading nested objects from state.
-      // For now, the only persisted state is `recentlyUsedKeysState` and we solved this issue
-      // by "teaching" zustand how to go a level deeper when merging this state.
-      // If we add another nested object to be persisted, we should look for
-      // a more general solution for deep merging.
+      // We solved this issue by "teaching" zustand how to go a level deeper when merging this state.
+  
       merge: (persisted, current) => ({
         ...current,
         timeframeState: {

--- a/web/src/features/search/stores/spanSearchStore.ts
+++ b/web/src/features/search/stores/spanSearchStore.ts
@@ -15,6 +15,7 @@
  */
 
 import create, { StateCreator } from "zustand";
+import { createJSONStorage, persist, StateStorage } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { Operator, SearchFilter, Sort } from "@/features/search";
@@ -205,11 +206,66 @@ const createSortSlice: StateCreator<
   },
 });
 
+const hashStorage: StateStorage = {
+  getItem: (key) => {
+    const searchParams = new URLSearchParams(window.location.hash.slice(1));
+    const storedValue = searchParams.get(key) ?? "";
+    return storedValue !== "" ? JSON.parse(storedValue) : null;
+  },
+  setItem: (key, newValue) => {
+    const searchParams = new URLSearchParams(window.location.hash.slice(1));
+    searchParams.set(key, JSON.stringify(newValue));
+    window.location.hash = searchParams.toString();
+  },
+  removeItem: (key) => {
+    const searchParams = new URLSearchParams(window.location.hash.slice(1));
+    searchParams.delete(key);
+    window.location.hash = searchParams.toString();
+  },
+};
+
 export const useSpanSearchStore = create<
   TimeframeSlice & LiveSpansSlice & FiltersSlice & SortSlice
->()((...set) => ({
+>()(
+persist(
+  (...set) => ({
   ...createTimeframeSlice(...set),
   ...createLiveSpansSlice(...set),
   ...createFiltersSlice(...set),
   ...createSortSlice(...set),
-}));
+}),
+{
+  name: "spansearch-hash-storage",
+  storage: createJSONStorage(()=> hashStorage),
+  // By default, zustand's merge function is shallow and it causes hydration issues
+  // when loading nested objects from state.
+  // For now, the only persisted state is `recentlyUsedKeysState` and we solved this issue
+  // by "teaching" zustand how to go a level deeper when merging this state.
+  // If we add another nested object to be persisted, we should look for
+  // a more general solution for deep merging.
+  merge: (persisted, current) => ({
+    ...current,
+    timeframeState: {
+      ...current.timeframeState,
+      currentTimeframe: {
+        startTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState.currentTimeframe.startTimeUnixNanoSec,
+        endTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState.currentTimeframe.endTimeUnixNanoSec,
+        isRelative: (persisted as TimeframeSlice).timeframeState.currentTimeframe.isRelative,
+      }
+    },
+    filtersState: {
+      ...current.filtersState,
+      filters: (persisted as FiltersSlice).filtersState.filters
+    },
+    liveSpansState: {
+      ...current.liveSpansState,
+      isOn: (persisted as LiveSpansSlice).liveSpansState.isOn,
+      intervalInMillis: (persisted as LiveSpansSlice).liveSpansState.intervalInMillis
+    },
+    sortState: {
+      ...current.sortState, 
+      sort: (persisted as SortSlice).sortState.sort
+    }
+  })
+},
+));

--- a/web/src/features/search/stores/spanSearchStore.ts
+++ b/web/src/features/search/stores/spanSearchStore.ts
@@ -15,7 +15,7 @@
  */
 
 import create, { StateCreator } from "zustand";
-import { createJSONStorage, persist, StateStorage } from "zustand/middleware";
+import { StateStorage, createJSONStorage, persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 import { Operator, SearchFilter, Sort } from "@/features/search";
@@ -227,45 +227,50 @@ const hashStorage: StateStorage = {
 export const useSpanSearchStore = create<
   TimeframeSlice & LiveSpansSlice & FiltersSlice & SortSlice
 >()(
-persist(
-  (...set) => ({
-  ...createTimeframeSlice(...set),
-  ...createLiveSpansSlice(...set),
-  ...createFiltersSlice(...set),
-  ...createSortSlice(...set),
-}),
-{
-  name: "spansearch-hash-storage",
-  storage: createJSONStorage(()=> hashStorage),
-  // By default, zustand's merge function is shallow and it causes hydration issues
-  // when loading nested objects from state.
-  // For now, the only persisted state is `recentlyUsedKeysState` and we solved this issue
-  // by "teaching" zustand how to go a level deeper when merging this state.
-  // If we add another nested object to be persisted, we should look for
-  // a more general solution for deep merging.
-  merge: (persisted, current) => ({
-    ...current,
-    timeframeState: {
-      ...current.timeframeState,
-      currentTimeframe: {
-        startTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState.currentTimeframe.startTimeUnixNanoSec,
-        endTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState.currentTimeframe.endTimeUnixNanoSec,
-        isRelative: (persisted as TimeframeSlice).timeframeState.currentTimeframe.isRelative,
-      }
-    },
-    filtersState: {
-      ...current.filtersState,
-      filters: (persisted as FiltersSlice).filtersState.filters
-    },
-    liveSpansState: {
-      ...current.liveSpansState,
-      isOn: (persisted as LiveSpansSlice).liveSpansState.isOn,
-      intervalInMillis: (persisted as LiveSpansSlice).liveSpansState.intervalInMillis
-    },
-    sortState: {
-      ...current.sortState, 
-      sort: (persisted as SortSlice).sortState.sort
+  persist(
+    (...set) => ({
+      ...createTimeframeSlice(...set),
+      ...createLiveSpansSlice(...set),
+      ...createFiltersSlice(...set),
+      ...createSortSlice(...set),
+    }),
+    {
+      name: "spansearch-hash-storage",
+      storage: createJSONStorage(() => hashStorage),
+      // By default, zustand's merge function is shallow and it causes hydration issues
+      // when loading nested objects from state.
+      // For now, the only persisted state is `recentlyUsedKeysState` and we solved this issue
+      // by "teaching" zustand how to go a level deeper when merging this state.
+      // If we add another nested object to be persisted, we should look for
+      // a more general solution for deep merging.
+      merge: (persisted, current) => ({
+        ...current,
+        timeframeState: {
+          ...current.timeframeState,
+          currentTimeframe: {
+            startTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState
+              .currentTimeframe.startTimeUnixNanoSec,
+            endTimeUnixNanoSec: (persisted as TimeframeSlice).timeframeState
+              .currentTimeframe.endTimeUnixNanoSec,
+            isRelative: (persisted as TimeframeSlice).timeframeState
+              .currentTimeframe.isRelative,
+          },
+        },
+        filtersState: {
+          ...current.filtersState,
+          filters: (persisted as FiltersSlice).filtersState.filters,
+        },
+        liveSpansState: {
+          ...current.liveSpansState,
+          isOn: (persisted as LiveSpansSlice).liveSpansState.isOn,
+          intervalInMillis: (persisted as LiveSpansSlice).liveSpansState
+            .intervalInMillis,
+        },
+        sortState: {
+          ...current.sortState,
+          sort: (persisted as SortSlice).sortState.sort,
+        },
+      }),
     }
-  })
-},
-));
+  )
+);


### PR DESCRIPTION
## What this PR does:
add spansearch hash storage and use Zustand merge for deep merging.
add functionality to display the right timeframe from the store.

## Which issue(s) this PR fixes:

Fixes #808 

https://github.com/teletrace/teletrace/assets/24496866/cc948b2a-5bfc-4716-aee4-d0e0c823ee3b
